### PR TITLE
fix: messed up comment indentation

### DIFF
--- a/lua/Comment/comment.lua
+++ b/lua/Comment/comment.lua
@@ -111,7 +111,7 @@ function C.setup(cfg)
             local is_commented = true
 
             -- When commenting multiple line, it is to be expected that indentation should be preserved
-            -- So, When looping over multiple lines we need to store the indentation of the mininum length
+            -- So, When looping over multiple lines we need to store the indentation of the mininum length (except empty line)
             -- Which will be used to semantically comment rest of the lines
             local min_indent = nil
 
@@ -120,8 +120,8 @@ function C.setup(cfg)
                 if is_commented and not is_cmt then
                     is_commented = false
                 end
-                local spc = line:match('(%s*)')
-                if not min_indent or #min_indent > #spc then
+                local spc, ln = U.split_half(line)
+                if not min_indent or (#min_indent > #spc) and #ln > 0 then
                     min_indent = spc
                 end
             end

--- a/lua/Comment/comment.lua
+++ b/lua/Comment/comment.lua
@@ -18,6 +18,7 @@
 --      [x] determine comment status (to comment or not)
 -- [x] prevent uncomment on uncommented line
 -- [x] `comment` and `toggle` misbehaving when there is leading space
+-- [x] messed up indentation, if the first line has greater indentation than next line (calc min indendation)
 -- [ ] `gcc` empty line not toggling comment
 
 -- THINK:
@@ -108,28 +109,28 @@ function C.setup(cfg)
             -- While commenting a block of text, there is a possiblity of lines being both commented and non-commented
             -- In that case, we need to figure out that if any line is uncommented then we should comment the whole block or vise-versa
             local is_commented = true
+
+            -- When commenting multiple line, it is to be expected that indentation should be preserved
+            -- So, When looping over multiple lines we need to store the indentation of the mininum length
+            -- Which will be used to semantically comment rest of the lines
+            local min_indent = nil
+
             for _, line in ipairs(lines) do
                 local is_cmt = U.is_commented(line, r_cs_esc)
-                if not is_cmt then
+                if is_commented and not is_cmt then
                     is_commented = false
-                    break
+                end
+                local spc = line:match('(%s*)')
+                if not min_indent or #min_indent > #spc then
+                    min_indent = spc
                 end
             end
 
-            -- When commenting multiple line, it is to be expected that indentation should be preserved
-            -- So, When looping over multiple lines we need to store the indentation of the first lines
-            -- Which will be used to semantically comment rest of the lines
-            local indent = nil
             for _, line in ipairs(lines) do
                 if is_commented then
                     table.insert(repls, U.uncomment_str(line, r_cs_esc, vim.pesc(l_cs), C.config.padding))
                 else
-                    -- preserve indentation of the first line
-                    if not indent then
-                        local pad = line:match('(%s*)')
-                        indent = pad
-                    end
-                    table.insert(repls, U.comment_str(line, r_cs, l_cs, C.config.padding, indent))
+                    table.insert(repls, U.comment_str(line, r_cs, l_cs, C.config.padding, min_indent or ''))
                 end
             end
 

--- a/lua/Comment/utils.lua
+++ b/lua/Comment/utils.lua
@@ -44,7 +44,7 @@ function U.get_lines(mode)
 end
 
 function U.comment_str(str, r_cs, l_cs, is_pad, spacing)
-    local indent, ln = str:match('(%s*)(.*)')
+    local indent, ln = U.split_half(str)
 
     -- if line is empty then use the space argument
     -- this is required if you are to comment multiple lines
@@ -86,6 +86,10 @@ end
 
 function U.is_commented(line, r_cs_esc)
     return line:find('^%s*' .. r_cs_esc)
+end
+
+function U.split_half(ln)
+    return ln:match('(%s*)(.*)')
 end
 
 return U


### PR DESCRIPTION
This happens if the first line has greater indentation than the next line. In this case, we need to calculate the indentation of the minimum length but don't consider any empty line. So that comments would be aligned with the shortest line.