### PR TITLE
feat: `ignore` lines

### DIFF
--- a/dump.lua
+++ b/dump.lua
@@ -15,7 +15,7 @@
 -- [ ] Insert mode mapping (also move the cursor after commentstring)
 -- [ ] Port `commentstring` from tcomment
 -- [ ] Header comment
--- [ ] Ignore line
+-- [x] Ignore line
 -- [x] Disable `extra` mapping by default
 
 -- FIXME

--- a/lua/Comment/init.lua
+++ b/lua/Comment/init.lua
@@ -1,27 +1,8 @@
-local U = require('Comment.utils')
 local C = require('Comment.comment')
 
-local M = {
+return {
     setup = C.setup,
-    toggle = C.toggle_ln,
+    toggle = C.toggle,
+    comment = C.comment,
+    uncomment = C.uncomment,
 }
-
----Comments the current line
-function M.comment()
-    local rcs, lcs = C.unwrap_cstr()
-    local l = vim.api.nvim_get_current_line()
-
-    C.comment_ln(l, rcs, lcs)
-    U.is_hook(C.config.post_hook, -1)
-end
-
----Unomments the current line
-function M.uncomment()
-    local rcs, lcs = C.unwrap_cstr()
-    local line = vim.api.nvim_get_current_line()
-
-    C.uncomment_ln(line, vim.pesc(rcs), vim.pesc(lcs))
-    U.is_hook(C.config.post_hook, -1)
-end
-
-return M

--- a/lua/Comment/utils.lua
+++ b/lua/Comment/utils.lua
@@ -159,4 +159,12 @@ function U.is_commented(str, rcs_esc)
     return str:find('^%s*' .. rcs_esc)
 end
 
+---Check if the given line is ignored or not with the given pattern
+---@param ln string Line to be ignored
+---@param pat string Lua regex
+---@return boolean
+function U.ignore(ln, pat)
+    return pat and ln:find(pat) ~= nil
+end
+
 return U


### PR DESCRIPTION
Now you can ignore lines by giving a Lua regex to `ignore` in setup. Show below
```lua
require('Comment').setup({
    -- Following ignores any empty lines
    ignore = '^$'
})
```