### PR TITLE
[WIP] feat: use opleader for extra keymaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Following are the **default** config for the [`setup()`](#setup). If you want to
         ---extra mapping
         ---Includes `gco`, `gcO`, `gcA`
         extra = true,
+        use_opleader = false,
         ---extended mapping
         ---Includes `g>`, `g<`, `g>[count]{motion}` and `g<[count]{motion}`
         extended = false,

--- a/lua/Comment/comment.lua
+++ b/lua/Comment/comment.lua
@@ -115,6 +115,7 @@ function C.setup(opts)
             basic = true,
             ---extra mapping
             extra = true,
+            use_opleader = false,
             ---extended mapping
             extended = false,
         },
@@ -202,9 +203,15 @@ function C.setup(opts)
                 E.norm_A(U.ctype.line, cfg)
             end
 
-            map('n', 'gco', '<CMD>lua ___comment_norm_o()<CR>', map_opt)
-            map('n', 'gcO', '<CMD>lua ___comment_norm_O()<CR>', map_opt)
-            map('n', 'gcA', '<CMD>lua ___comment_norm_A()<CR>', map_opt)
+            if cfg.mappings.use_opleader then
+                    map('n', cfg.opleader.line .. 'o', '<CMD>lua ___comment_norm_o()<CR>', map_opt)
+                    map('n', cfg.opleader.line .. 'O', '<CMD>lua ___comment_norm_O()<CR>', map_opt)
+                    map('n', cfg.opleader.line .. 'A', '<CMD>lua ___comment_norm_A()<CR>', map_opt)
+            else
+                    map('n', 'gco', '<CMD>lua ___comment_norm_o()<CR>', map_opt)
+                    map('n', 'gcO', '<CMD>lua ___comment_norm_O()<CR>', map_opt)
+                    map('n', 'gcA', '<CMD>lua ___comment_norm_A()<CR>', map_opt)
+            end
         end
 
         -- Extended Mappings


### PR DESCRIPTION
I'd like a more consistent behavior between basic and extra mappings, since I see those extra mappings as operations ; thus, I propose to use a boolean (defaulting the `false`, current behavior) to allow users to use `opleader` as LHS for extra mappings in addition to basic ones.

Updated the README.md accordingly.