### PR TITLE
Add more comment types for common languages

### DIFF
--- a/lua/Comment/ft.lua
+++ b/lua/Comment/ft.lua
@@ -6,6 +6,7 @@ local M = {
     dash = '--%s',
     haskell_b = '{-%s-}',
     fsharp_b = '(*%s*)',
+    html_b = '<!--%s-->',
 }
 
 ---Lang table that contains commentstring (linewise/blockwise) for mutliple filetypes
@@ -22,7 +23,7 @@ local L = {
     graphql = { M.hash },
     groovy = { M.cxx_l, M.cxx_b },
     haskell = { M.dash, M.haskell_b },
-    html = { '%s', '<!--%s-->' },
+    html = { M.html_b, M.html_b },
     idris = { M.dash, M.haskell_b },
     java = { M.cxx_l, M.cxx_b },
     javascript = { M.cxx_l, M.cxx_b },
@@ -32,8 +33,8 @@ local L = {
     lua = { M.dash, '--[[%s--]]' },
     ocaml = { M.fsharp_b, M.fsharp_b },
     plantuml = { "'%s", "/'%s'/" },
-    python = { M.hash, '"""%s"""' },
     purescript = { M.dash, M.haskell_b },
+    python = { M.hash, '"""%s"""' },
     rust = { M.cxx_l, M.cxx_b },
     scala = { M.cxx_l, M.cxx_b },
     sh = { M.hash },
@@ -43,8 +44,9 @@ local L = {
     toml = { M.hash },
     typescript = { M.cxx_l, M.cxx_b },
     typescriptreact = { M.cxx_l, M.cxx_b },
+    vim = { '"%s' },
+    xml = { M.html_b, M.html_b },
     yaml = { M.hash },
-    vim = { "\"%s" },
     zig = { M.cxx_l }, -- Zig doesn't have block comments. waaaattttt!
 }
 


### PR DESCRIPTION
Add support for comments in HTML, python, shell, sql, and vimscript.