### PR TITLE
feat: lua api for `gc`, `gcc`, `gb`, `gbc` 🎉 

### DIFF
--- a/API.md
+++ b/API.md
@@ -1,6 +1,0 @@
-Coming soon :)
-
-<!-- TODO: -->
-<!-- - Document `opfunc` -->
-<!-- - Document `extra` -->
-<!-- - Document `utils` -->

--- a/README.md
+++ b/README.md
@@ -113,11 +113,11 @@ Following are the **default** config for the [`setup()`](#setup). If you want to
     },
 
     ---Pre-hook, called before commenting the line
-    ---@type function
+    ---@type fun(ctx: Ctx):string
     pre_hook = nil,
 
     ---Post-hook, called after commenting is done
-    ---@type function
+    ---@type fun(ctx: Ctx)
     post_hook = nil,
 }
 ```

--- a/README.md
+++ b/README.md
@@ -213,26 +213,11 @@ These mappings are disabled by default. (config: `mappings.extended`)
 `gbac` - Toggle comment around a class (w/ LSP/treesitter support)
 ```
 
-#### Methods
-
-`Comment.nvim` also provides some methods apart from the [mappings](#mappings). Also note that these methods only do linewise commenting and only on the current line.
-
-```lua
--- Comments the current line
-require('Comment').comment()
-
--- Uncomments the current lines
-require('Comment').uncomment()
-
--- Toggles the current lines
-require('Comment').toggle()
-```
-
 <a id="api"></a>
 
 ### ⚙️ API
 
-Read [API](./API.md) for more crazy stuff.
+Read [doc/API.md](./doc/API.md) to see all the API/functions that are exported from the plugin.
 
 <a id="treesitter"></a>
 

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Following are the **default** config for the [`setup()`](#setup). If you want to
 The configuration is also exported by the following method. But make to sure to call [setup](#setup) first.
 
 ```lua
-require('Comment').get_config()
+require('Comment.api').get_config()
 ```
 
 ### 🔥 Usage

--- a/README.md
+++ b/README.md
@@ -125,7 +125,12 @@ Following are the **default** config for the [`setup()`](#setup). If you want to
 The configuration is also exported by the following method. But make to sure to call [setup](#setup) first.
 
 ```lua
+-- NOTE: This directly returns the config without copying it. So modifying it directly could have some side effects.
 require('Comment.api').get_config()
+
+-- You can do this instead to safely modify it, if you want.
+local api = require('Comment.api')
+local config = vim.deepcopy(api.get_config())
 ```
 
 ### 🔥 Usage

--- a/doc/API.md
+++ b/doc/API.md
@@ -1,0 +1,56 @@
+# ⚙️ API
+
+### Core
+
+```lua
+---Toggle comment on a line
+require('Comment.api').toggle()
+
+---Comment a line
+require('Comment.api').comment()
+
+---Uncomment a line
+require('Comment.api').uncomment()
+
+---Line comment with a count
+---@param count integer Number of lines. (default: `vim.v.count`)
+---@param cfg Config If not provided, will use the default config
+require('Comment.api').count_gcc(count, cfg)
+
+---Toggle comment using linewise comment. This powers the default `gcc` mapping.
+---@param vmode VMode
+---@param cfg Config
+require('Comment.api').gcc(vmode, cfg)
+
+---Toggle comment using blockwise comment. This powers the default `gbc` mapping.
+---@param vmode VMode
+---@param cfg Config
+require('Comment.api').gbc(vmode, cfg)
+
+---(Operator-Pending) Toggle comment using linewise comment. This powers the default `gc` mapping.
+---@param vmode VMode
+---@param cfg Config
+require('Comment.api').gc(vmode, cfg)
+
+---(Operator-Pending) Toggle comment using blockwise comment. This powers the default `gb` mapping.
+---@param vmode VMode
+---@param cfg Config
+require('Comment.api').gb(vmode, cfg)
+```
+
+> If you enabled `config.mappings.extra` then you can get access to these
+
+```lua
+---Add comment on the line below and go to insert-mode
+require('Comment.api').gco()
+
+---Add comment on the line above and go to insert-mode
+require('Comment.api').gcO()
+
+---Add comment at the end-of-line and go to insert-mode
+require('Comment.api').gcA()
+```
+
+<!-- TODO: -->
+<!-- - Document `opfunc` -->
+<!-- - Document `extra` -->

--- a/doc/API.md
+++ b/doc/API.md
@@ -6,13 +6,13 @@
 ---@alias VMode 'line'|'char'|'v'|'V' Vim Mode. Read `:h map-operator`
 ---@alias cfg table Same as `.setup({cfg})`
 
----Toggle comment on a line
+---Toggle comment on the current line (using linewise comment)
 require('Comment.api').toggle()
 
----Comment a line
+---Comment the current line (using linewise comment)
 require('Comment.api').comment()
 
----Uncomment a line
+---Uncomment the current line (using linewise comment)
 require('Comment.api').uncomment()
 
 ---Line comment with a count

--- a/doc/API.md
+++ b/doc/API.md
@@ -9,7 +9,7 @@
 
 ```lua
 ---@alias VMode 'line'|'char'|'v'|'V' Vim Mode. Read `:h map-operator`
----@alias cfg table Same as `.setup({cfg})`
+---@alias Config table Read https://github.com/numToStr/Comment.nvim/tree/master#configuration-optional
 
 ---Toggle comment on the current line (using linewise comment)
 require('Comment.api').toggle()

--- a/doc/API.md
+++ b/doc/API.md
@@ -2,6 +2,11 @@
 
 ### Core
 
+<!-- ---Line comment with a count -->
+<!-- ---@param count integer Number of lines. (default: `vim.v.count`) -->
+<!-- ---@param cfg Config If not provided, will use the default config -->
+<!-- require('Comment.api').gcc_count(count, cfg) -->
+
 ```lua
 ---@alias VMode 'line'|'char'|'v'|'V' Vim Mode. Read `:h map-operator`
 ---@alias cfg table Same as `.setup({cfg})`
@@ -14,11 +19,6 @@ require('Comment.api').comment()
 
 ---Uncomment the current line (using linewise comment)
 require('Comment.api').uncomment()
-
----Line comment with a count
----@param count integer Number of lines. (default: `vim.v.count`)
----@param cfg Config If not provided, will use the default config
-require('Comment.api').gcc_count(count, cfg)
 
 ---Toggle comment using linewise comment. This powers the default `gcc` mapping.
 ---@param vmode VMode

--- a/doc/API.md
+++ b/doc/API.md
@@ -3,6 +3,9 @@
 ### Core
 
 ```lua
+---@alias VMode 'line'|'char'|'v'|'V' Vim Mode. Read `:h map-operator`
+---@alias cfg table Same as `.setup({cfg})`
+
 ---Toggle comment on a line
 require('Comment.api').toggle()
 

--- a/doc/API.md
+++ b/doc/API.md
@@ -41,6 +41,8 @@ require('Comment.api').gc(vmode, cfg)
 require('Comment.api').gb(vmode, cfg)
 ```
 
+> NOTE: If `cfg` argument is not provided, then the [default config](https://github.com/numToStr/Comment.nvim/tree/master#configuration-optional) will be used or the custom config provided during the [`setup()`](https://github.com/numToStr/Comment.nvim/tree/master#setup). BTW, You can also use these function without calling the `setup()` :)
+
 > If you enabled `config.mappings.extra` then you can get access to these
 
 ```lua

--- a/doc/API.md
+++ b/doc/API.md
@@ -18,7 +18,7 @@ require('Comment.api').uncomment()
 ---Line comment with a count
 ---@param count integer Number of lines. (default: `vim.v.count`)
 ---@param cfg Config If not provided, will use the default config
-require('Comment.api').count_gcc(count, cfg)
+require('Comment.api').gcc_count(count, cfg)
 
 ---Toggle comment using linewise comment. This powers the default `gcc` mapping.
 ---@param vmode VMode

--- a/dump.lua
+++ b/dump.lua
@@ -1,5 +1,5 @@
 -- TODO
--- [-] Handle Tabs
+-- [x] Handle Tabs
 -- [x] Dot repeat
 -- [x] Comment multiple line.
 -- [x] Hook support
@@ -12,20 +12,17 @@
 --      [x] Partial blocks ie. gba{ gbaf
 --      [ ] V-BLOCK (IDK, maybe)
 --      [ ] Char motion covering mutliple lines ie. gc300w (level: HARD)
--- [ ] Doc comment ie. /** */ (for js)
--- [ ] Treesitter Integration
+-- [-] Treesitter Integration
 --      [ ] Better comment detection
---      [ ] Context commentstring
--- [ ] Insert mode mapping (also move the cursor after commentstring)
--- [-] Port `commentstring` from tcomment
--- [ ] Header comment
+--      [x] Context commentstring
+-- [x] Port `commentstring` from tcomment
 -- [x] Ignore line
 -- [x] Disable `extra` mapping by default
 -- [x] Provide more arguments to pre and post hooks
 -- [x] `ignore` as a function
--- [ ] Parse `set comments` if block comment is missing in the plugin
--- [ ] Use `nvim_buf_get_text` instead of `nvim_buf_get_lines`. Blocked by https://github.com/neovim/neovim/pull/15181
--- [ ] Use `nvim_buf_set_text` instead of `nvim_buf_set_lines`
+-- [ ] Doc comment ie. /** */ (for js)
+-- [ ] Header comment
+-- [ ] Dot support for `[count]gcc`
 
 -- FIXME
 -- [x] visual mode not working correctly
@@ -44,10 +41,16 @@
 -- [ ] Weird comments, if you do comments on already commented lines incl. an extra empty line
 
 -- THINK:
--- 1. Should i return the operator's starting and ending position in pre-hook
--- 2. Restore initial cursor position in some motion operator (try `gcip`)
+-- [x] Should i return the operator's starting and ending position in pre-hook
+-- [x] Restore cursor position in some motion operator (try `gcip`)
 -- 3. It is possible that, commentstring is updated inside pre-hook as we want to use it but we can't
---    bcz the filetype is also present in the lang-table (and it has high priority than bo.commentstring)
+--    bcz the filetype is also present in the lang-table (and it has high priority than vim.bo.commentstring)
 -- 4. When there is an uncommented empty line b/w two commented blocks. It should uncomment instead of commenting again in toggle.
 -- 5. Conflict when uncommenting interchangebly with line/block wise comment
 -- 6. `ignore` is missing in blockwise and blockwise_x but on the other hand this doesn't make much sense
+-- 7. Parse `comments` if block comment is missing in the plugin
+
+-- DROPPED:
+-- Insert mode mapping (also move the cursor after commentstring)
+-- Use `nvim_buf_get_text` instead of `nvim_buf_get_lines`. Blocked by https://github.com/neovim/neovim/pull/15181
+-- Use `nvim_buf_set_text` instead of `nvim_buf_set_lines`

--- a/lua/Comment/api.lua
+++ b/lua/Comment/api.lua
@@ -128,9 +128,10 @@ function C.toggle()
 end
 
 ---Does line comment with a count i.e vim.v.count
+---@param count integer Number of lines
 ---@param cfg Config
-function C.count_gcc(cfg)
-    Op.count(cfg or C.config)
+function C.gcc_count(count, cfg)
+    Op.count(count or vim.v.count, cfg or C.config)
 end
 
 ---Toggle comment using linewise comment
@@ -206,7 +207,7 @@ function C.setup(opts)
             map(
                 'n',
                 cfg.toggler.line,
-                [[v:count == 0 ? '<CMD>lua require("Comment.api").call("gcc")<CR>g@$' : '<CMD>lua require("Comment.api").count_gcc()<CR>']],
+                [[v:count == 0 ? '<CMD>lua require("Comment.api").call("gcc")<CR>g@$' : '<CMD>lua require("Comment.api").gcc_count()<CR>']],
                 { noremap = true, silent = true, expr = true }
             )
             map('n', cfg.toggler.block, '<CMD>lua require("Comment.api").call("gbc")<CR>g@$', map_opt)

--- a/lua/Comment/api.lua
+++ b/lua/Comment/api.lua
@@ -1,7 +1,45 @@
 local Op = require('Comment.opfunc')
 local U = require('Comment.utils')
-
 local A = vim.api
+
+---LHS of toggle mappings in NORMAL + VISUAL mode
+---@class Toggler
+---@field line string Linewise comment keymap
+---@field block string Blockwise comment keymap
+
+---LHS of operator-pending mappings in NORMAL + VISUAL mode
+---@class Opleader
+---@field line string Linewise comment keymap
+---@field block string Blockwise comment keymap
+
+---Whether to create basic (operator-pending) and extended mappings
+---@class Mappings
+---Enable operator-pending mapping
+---Includes `gcc`, `gcb`, `gc[count]{motion}` and `gb[count]{motion}`
+---NOTE: These mappings can be changed individually by `opleader` and `toggler` config
+---@field basic boolean
+---Enable extra mapping
+---Includes `gco`, `gcO`, `gcA`
+---@field extra boolean
+---Enable extended mapping
+---Includes `g>`, `g<`, `g>[count]{motion}` and `g<[count]{motion}`
+---@field extended boolean
+
+---Plugin's config
+---@class Config
+---@field padding boolean Add a space b/w comment and the line
+---Whether the cursor should stay at its position
+---NOTE: This only affects NORMAL mode mappings and doesn't work with dot-repeat
+---@field sticky boolean
+---Lines to be ignored while comment/uncomment.
+---Could be a regex string or a function that returns a regex string.
+---Example: Use '^$' to ignore empty lines
+---@field ignore string|function
+---@field mappings Mappings
+---@field toggler Toggler
+---@field opleader Opleader
+---@field pre_hook fun(ctx: Ctx):string Function to be called before comment/uncomment
+---@field post_hook fun(ctx:Ctx) Function to be called after comment/uncomment
 
 local C = {
     ---@type Config
@@ -126,52 +164,23 @@ end
 ---Configures the whole plugin
 ---@param opts Config
 function C.setup(opts)
-    ---Plugin config
-    ---@class Config
+    ---@type Config
     C.config = {
-        ---Add a space b/w comment and the line
-        ---@type boolean
         padding = true,
-        ---Whether the cursor should stay at its position
-        ---This only affects NORMAL mode mappings
-        ---@type boolean
         sticky = true,
-        ---Line which should be ignored while comment/uncomment
-        ---Example: Use '^$' to ignore empty lines
-        ---@type string|function Lua regex
-        ignore = nil,
-        ---Whether to create basic (operator-pending) and extended mappings
-        ---@type table
         mappings = {
-            ---operator-pending mapping
             basic = true,
-            ---extra mapping
             extra = true,
-            ---extended mapping
             extended = false,
         },
-        ---LHS of toggle mapping in NORMAL mode for line and block comment
-        ---@type table
         toggler = {
-            ---LHS of line-comment toggle
             line = 'gcc',
-            ---LHS of block-comment toggle
             block = 'gbc',
         },
-        ---LHS of operator-mode mapping in NORMAL/VISUAL mode for line and block comment
-        ---@type table
         opleader = {
-            ---LHS of line-comment opfunc mapping
             line = 'gc',
-            ---LHS of block-comment opfunc mapping
             block = 'gb',
         },
-        ---Pre-hook, called before commenting the line
-        ---@type function|nil
-        pre_hook = nil,
-        ---Post-hook, called after commenting is done
-        ---@type function|nil
-        post_hook = nil,
     }
 
     if opts ~= nil then

--- a/lua/Comment/api.lua
+++ b/lua/Comment/api.lua
@@ -46,6 +46,12 @@ local C = {
     config = nil,
 }
 
+---Get the plugin's config
+---@return Config
+function C.get_config()
+    return C.config
+end
+
 ---Comments the current line
 function C.comment()
     local line = A.nvim_get_current_line()

--- a/lua/Comment/api.lua
+++ b/lua/Comment/api.lua
@@ -127,13 +127,6 @@ function C.toggle()
     end
 end
 
----Does line comment with a count i.e vim.v.count
----@param count integer Number of lines
----@param cfg Config
-function C.gcc_count(count, cfg)
-    Op.count(count or vim.v.count, cfg or C.config)
-end
-
 ---Toggle comment using linewise comment
 ---@param vmode VMode
 ---@param cfg Config
@@ -203,6 +196,11 @@ function C.setup(opts)
 
         -- Basic Mappings
         if cfg.mappings.basic then
+            ---@private
+            function C.gcc_count()
+                Op.count(vim.v.count, cfg)
+            end
+
             -- NORMAL mode mappings
             map(
                 'n',

--- a/lua/Comment/api.lua
+++ b/lua/Comment/api.lua
@@ -96,28 +96,28 @@ function C.count_gcc(cfg)
 end
 
 ---Toggle comment using linewise comment
----@param vmode string Vim Mode. Read `:h :map-operator`
+---@param vmode VMode
 ---@param cfg Config
 function C.gcc(vmode, cfg)
     Op.opfunc(vmode, cfg or C.config, U.cmode.toggle, U.ctype.line, U.cmotion.line)
 end
 
 ---Toggle comment using blockwise comment
----@param vmode string Vim Mode. Read `:h :map-operator`
+---@param vmode VMode
 ---@param cfg Config
 function C.gbc(vmode, cfg)
     Op.opfunc(vmode, cfg or C.config, U.cmode.toggle, U.ctype.block, U.cmotion.line)
 end
 
 ---(Operator-Pending) Toggle comment using linewise comment
----@param vmode string Vim Mode. Read `:h :map-operator`
+---@param vmode VMode
 ---@param cfg Config
 function C.gc(vmode, cfg)
     Op.opfunc(vmode, cfg or C.config, U.cmode.toggle, U.ctype.line, U.cmotion._)
 end
 
 ---(Operator-Pending) Toggle comment using blockwise comment
----@param vmode string Vim Mode. Read `:h :map-operator`
+---@param vmode VMode
 ---@param cfg Config
 function C.gb(vmode, cfg)
     Op.opfunc(vmode, cfg or C.config, U.cmode.toggle, U.ctype.block, U.cmotion._)
@@ -126,6 +126,7 @@ end
 ---Configures the whole plugin
 ---@param opts Config
 function C.setup(opts)
+    ---Plugin config
     ---@class Config
     C.config = {
         ---Add a space b/w comment and the line

--- a/lua/Comment/api.lua
+++ b/lua/Comment/api.lua
@@ -187,7 +187,7 @@ function C.setup(opts)
         -- NOTE: We are using cfg to store the position as the cfg is tossed around in most places
         function C.call(cb)
             cfg.___pos = cfg.sticky and A.nvim_win_get_cursor(0)
-            vim.o.operatorfunc = "v:lua.require'Comment.comment'." .. cb
+            vim.o.operatorfunc = "v:lua.require'Comment.api'." .. cb
         end
 
         -- Basic Mappings
@@ -196,21 +196,16 @@ function C.setup(opts)
             map(
                 'n',
                 cfg.toggler.line,
-                [[v:count == 0 ? '<CMD>lua require("Comment.comment").call("gcc")<CR>g@$' : '<CMD>lua require("Comment.comment").count_gcc()<CR>']],
+                [[v:count == 0 ? '<CMD>lua require("Comment.api").call("gcc")<CR>g@$' : '<CMD>lua require("Comment.api").count_gcc()<CR>']],
                 { noremap = true, silent = true, expr = true }
             )
-            map('n', cfg.toggler.block, '<CMD>lua require("Comment.comment").call("gbc")<CR>g@$', map_opt)
-            map('n', cfg.opleader.line, '<CMD>lua require("Comment.comment").call("gc")<CR>g@', map_opt)
-            map('n', cfg.opleader.block, '<CMD>lua require("Comment.comment").call("gb")<CR>g@', map_opt)
+            map('n', cfg.toggler.block, '<CMD>lua require("Comment.api").call("gbc")<CR>g@$', map_opt)
+            map('n', cfg.opleader.line, '<CMD>lua require("Comment.api").call("gc")<CR>g@', map_opt)
+            map('n', cfg.opleader.block, '<CMD>lua require("Comment.api").call("gb")<CR>g@', map_opt)
 
             -- VISUAL mode mappings
-            map('x', cfg.opleader.line, '<ESC><CMD>lua require("Comment.comment").gc(vim.fn.visualmode())<CR>', map_opt)
-            map(
-                'x',
-                cfg.opleader.block,
-                '<ESC><CMD>lua require("Comment.comment").gb(vim.fn.visualmode())<CR>',
-                map_opt
-            )
+            map('x', cfg.opleader.line, '<ESC><CMD>lua require("Comment.api").gc(vim.fn.visualmode())<CR>', map_opt)
+            map('x', cfg.opleader.block, '<ESC><CMD>lua require("Comment.api").gb(vim.fn.visualmode())<CR>', map_opt)
         end
 
         -- Extra Mappings
@@ -227,9 +222,9 @@ function C.setup(opts)
                 E.norm_A(U.ctype.line, cfg)
             end
 
-            map('n', 'gco', '<CMD>lua require("Comment.comment").gco()<CR>', map_opt)
-            map('n', 'gcO', '<CMD>lua require("Comment.comment").gcO()<CR>', map_opt)
-            map('n', 'gcA', '<CMD>lua require("Comment.comment").gcA()<CR>', map_opt)
+            map('n', 'gco', '<CMD>lua require("Comment.api").gco()<CR>', map_opt)
+            map('n', 'gcO', '<CMD>lua require("Comment.api").gcO()<CR>', map_opt)
+            map('n', 'gcA', '<CMD>lua require("Comment.api").gcA()<CR>', map_opt)
         end
 
         -- Extended Mappings
@@ -255,17 +250,17 @@ function C.setup(opts)
             end
 
             -- NORMAL mode extended
-            map('n', 'g>', '<CMD>lua require("Comment.comment").call("ggt")<CR>g@', map_opt)
-            map('n', 'g>c', '<CMD>lua require("Comment.comment").call("ggtc")<CR>g@$', map_opt)
-            map('n', 'g>b', '<CMD>lua require("Comment.comment").call("ggtb")<CR>g@$', map_opt)
+            map('n', 'g>', '<CMD>lua require("Comment.api").call("ggt")<CR>g@', map_opt)
+            map('n', 'g>c', '<CMD>lua require("Comment.api").call("ggtc")<CR>g@$', map_opt)
+            map('n', 'g>b', '<CMD>lua require("Comment.api").call("ggtb")<CR>g@$', map_opt)
 
-            map('n', 'g<', '<CMD>lua require("Comment.comment").call("glt")<CR>g@', map_opt)
-            map('n', 'g<c', '<CMD>lua require("Comment.comment").call("gltc")<CR>g@$', map_opt)
-            map('n', 'g<b', '<CMD>lua require("Comment.comment").call("gltb")<CR>g@$', map_opt)
+            map('n', 'g<', '<CMD>lua require("Comment.api").call("glt")<CR>g@', map_opt)
+            map('n', 'g<c', '<CMD>lua require("Comment.api").call("gltc")<CR>g@$', map_opt)
+            map('n', 'g<b', '<CMD>lua require("Comment.api").call("gltb")<CR>g@$', map_opt)
 
             -- VISUAL mode extended
-            map('x', 'g>', '<ESC><CMD>lua require("Comment.comment").ggt(vim.fn.visualmode())<CR>', map_opt)
-            map('x', 'g<', '<ESC><CMD>lua require("Comment.comment").glt(vim.fn.visualmode())<CR>', map_opt)
+            map('x', 'g>', '<ESC><CMD>lua require("Comment.api").ggt(vim.fn.visualmode())<CR>', map_opt)
+            map('x', 'g<', '<ESC><CMD>lua require("Comment.api").glt(vim.fn.visualmode())<CR>', map_opt)
         end
     end
 end

--- a/lua/Comment/comment.lua
+++ b/lua/Comment/comment.lua
@@ -88,6 +88,26 @@ function C.toggle()
     end
 end
 
+function C.count_gcc(cfg)
+    require('Comment.opfunc').count(cfg or C.config)
+end
+
+function C.gcc(vmode, cfg)
+    require('Comment.opfunc').opfunc(vmode, cfg or C.config, U.cmode.toggle, U.ctype.line, U.cmotion.line)
+end
+
+function C.gbc(vmode, cfg)
+    require('Comment.opfunc').opfunc(vmode, cfg or C.config, U.cmode.toggle, U.ctype.block, U.cmotion.line)
+end
+
+function C.gc(vmode, cfg)
+    require('Comment.opfunc').opfunc(vmode, cfg or C.config, U.cmode.toggle, U.ctype.line, U.cmotion._)
+end
+
+function C.gb(vmode, cfg)
+    require('Comment.opfunc').opfunc(vmode, cfg or C.config, U.cmode.toggle, U.ctype.block, U.cmotion._)
+end
+
 ---Configures the whole plugin
 ---@param opts Config
 function C.setup(opts)
@@ -145,50 +165,37 @@ function C.setup(opts)
     local cfg = C.config
 
     if cfg.mappings then
-        local Op = require('Comment.opfunc')
-
         local map = A.nvim_set_keymap
         local map_opt = { noremap = true, silent = true }
 
         -- Callback function to save cursor position and set operatorfunc
         -- NOTE: We are using cfg to store the position as the cfg is tossed around in most places
-        function _G.___comment_call(cb)
+        function C.call(cb)
             cfg.___pos = cfg.sticky and A.nvim_win_get_cursor(0)
-            vim.o.operatorfunc = 'v:lua.___comment_' .. cb
+            vim.o.operatorfunc = "v:lua.require'Comment.comment'." .. cb
         end
 
         -- Basic Mappings
         if cfg.mappings.basic then
-            function _G.___comment_count_gcc()
-                Op.count(cfg)
-            end
-            function _G.___comment_gcc(vmode)
-                Op.opfunc(cfg, vmode, U.cmode.toggle, U.ctype.line, U.cmotion.line)
-            end
-            function _G.___comment_gbc(vmode)
-                Op.opfunc(cfg, vmode, U.cmode.toggle, U.ctype.block, U.cmotion.line)
-            end
-            function _G.___comment_gc(vmode)
-                Op.opfunc(cfg, vmode, U.cmode.toggle, U.ctype.line, U.cmotion._)
-            end
-            function _G.___comment_gb(vmode)
-                Op.opfunc(cfg, vmode, U.cmode.toggle, U.ctype.block, U.cmotion._)
-            end
-
             -- NORMAL mode mappings
             map(
                 'n',
                 cfg.toggler.line,
-                [[v:count == 0 ? '<CMD>lua ___comment_call("gcc")<CR>g@$' : '<CMD>lua ___comment_count_gcc()<CR>']],
+                [[v:count == 0 ? '<CMD>lua require("Comment.comment").call("gcc")<CR>g@$' : '<CMD>lua require("Comment.comment").count_gcc()<CR>']],
                 { noremap = true, silent = true, expr = true }
             )
-            map('n', cfg.toggler.block, '<CMD>lua ___comment_call("gbc")<CR>g@$', map_opt)
-            map('n', cfg.opleader.line, '<CMD>lua ___comment_call("gc")<CR>g@', map_opt)
-            map('n', cfg.opleader.block, '<CMD>lua ___comment_call("gb")<CR>g@', map_opt)
+            map('n', cfg.toggler.block, '<CMD>lua require("Comment.comment").call("gbc")<CR>g@$', map_opt)
+            map('n', cfg.opleader.line, '<CMD>lua require("Comment.comment").call("gc")<CR>g@', map_opt)
+            map('n', cfg.opleader.block, '<CMD>lua require("Comment.comment").call("gb")<CR>g@', map_opt)
 
             -- VISUAL mode mappings
-            map('x', cfg.opleader.line, '<ESC><CMD>lua ___comment_gc(vim.fn.visualmode())<CR>', map_opt)
-            map('x', cfg.opleader.block, '<ESC><CMD>lua ___comment_gb(vim.fn.visualmode())<CR>', map_opt)
+            map('x', cfg.opleader.line, '<ESC><CMD>lua require("Comment.comment").gc(vim.fn.visualmode())<CR>', map_opt)
+            map(
+                'x',
+                cfg.opleader.block,
+                '<ESC><CMD>lua require("Comment.comment").gb(vim.fn.visualmode())<CR>',
+                map_opt
+            )
         end
 
         -- Extra Mappings
@@ -212,6 +219,8 @@ function C.setup(opts)
 
         -- Extended Mappings
         if cfg.mappings.extended then
+            local Op = require('Comment.opfunc')
+
             function _G.___comment_ggt(vmode)
                 Op.opfunc(cfg, vmode, U.cmode.comment, U.ctype.line, U.cmotion._)
             end

--- a/lua/Comment/comment.lua
+++ b/lua/Comment/comment.lua
@@ -1,3 +1,4 @@
+local Op = require('Comment.opfunc')
 local U = require('Comment.utils')
 
 local A = vim.api
@@ -89,23 +90,23 @@ function C.toggle()
 end
 
 function C.count_gcc(cfg)
-    require('Comment.opfunc').count(cfg or C.config)
+    Op.count(cfg or C.config)
 end
 
 function C.gcc(vmode, cfg)
-    require('Comment.opfunc').opfunc(vmode, cfg or C.config, U.cmode.toggle, U.ctype.line, U.cmotion.line)
+    Op.opfunc(vmode, cfg or C.config, U.cmode.toggle, U.ctype.line, U.cmotion.line)
 end
 
 function C.gbc(vmode, cfg)
-    require('Comment.opfunc').opfunc(vmode, cfg or C.config, U.cmode.toggle, U.ctype.block, U.cmotion.line)
+    Op.opfunc(vmode, cfg or C.config, U.cmode.toggle, U.ctype.block, U.cmotion.line)
 end
 
 function C.gc(vmode, cfg)
-    require('Comment.opfunc').opfunc(vmode, cfg or C.config, U.cmode.toggle, U.ctype.line, U.cmotion._)
+    Op.opfunc(vmode, cfg or C.config, U.cmode.toggle, U.ctype.line, U.cmotion._)
 end
 
 function C.gb(vmode, cfg)
-    require('Comment.opfunc').opfunc(vmode, cfg or C.config, U.cmode.toggle, U.ctype.block, U.cmotion._)
+    Op.opfunc(vmode, cfg or C.config, U.cmode.toggle, U.ctype.block, U.cmotion._)
 end
 
 ---Configures the whole plugin
@@ -219,8 +220,6 @@ function C.setup(opts)
 
         -- Extended Mappings
         if cfg.mappings.extended then
-            local Op = require('Comment.opfunc')
-
             function C.ggt(vmode)
                 Op.opfunc(cfg, vmode, U.cmode.comment, U.ctype.line, U.cmotion._)
             end

--- a/lua/Comment/comment.lua
+++ b/lua/Comment/comment.lua
@@ -4,7 +4,7 @@ local U = require('Comment.utils')
 local A = vim.api
 
 local C = {
-    ---@type Config|nil
+    ---@type Config
     config = nil,
 }
 
@@ -89,22 +89,36 @@ function C.toggle()
     end
 end
 
+---Does line comment with a count i.e vim.v.count
+---@param cfg Config
 function C.count_gcc(cfg)
     Op.count(cfg or C.config)
 end
 
+---Toggle comment using linewise comment
+---@param vmode string Vim Mode. Read `:h :map-operator`
+---@param cfg Config
 function C.gcc(vmode, cfg)
     Op.opfunc(vmode, cfg or C.config, U.cmode.toggle, U.ctype.line, U.cmotion.line)
 end
 
+---Toggle comment using blockwise comment
+---@param vmode string Vim Mode. Read `:h :map-operator`
+---@param cfg Config
 function C.gbc(vmode, cfg)
     Op.opfunc(vmode, cfg or C.config, U.cmode.toggle, U.ctype.block, U.cmotion.line)
 end
 
+---(Operator-Pending) Toggle comment using linewise comment
+---@param vmode string Vim Mode. Read `:h :map-operator`
+---@param cfg Config
 function C.gc(vmode, cfg)
     Op.opfunc(vmode, cfg or C.config, U.cmode.toggle, U.ctype.line, U.cmotion._)
 end
 
+---(Operator-Pending) Toggle comment using blockwise comment
+---@param vmode string Vim Mode. Read `:h :map-operator`
+---@param cfg Config
 function C.gb(vmode, cfg)
     Op.opfunc(vmode, cfg or C.config, U.cmode.toggle, U.ctype.block, U.cmotion._)
 end

--- a/lua/Comment/comment.lua
+++ b/lua/Comment/comment.lua
@@ -202,19 +202,19 @@ function C.setup(opts)
         if cfg.mappings.extra then
             local E = require('Comment.extra')
 
-            function _G.___comment_norm_o()
+            function C.gco()
                 E.norm_o(U.ctype.line, cfg)
             end
-            function _G.___comment_norm_O()
+            function C.gcO()
                 E.norm_O(U.ctype.line, cfg)
             end
-            function _G.___comment_norm_A()
+            function C.gcA()
                 E.norm_A(U.ctype.line, cfg)
             end
 
-            map('n', 'gco', '<CMD>lua ___comment_norm_o()<CR>', map_opt)
-            map('n', 'gcO', '<CMD>lua ___comment_norm_O()<CR>', map_opt)
-            map('n', 'gcA', '<CMD>lua ___comment_norm_A()<CR>', map_opt)
+            map('n', 'gco', '<CMD>lua require("Comment.comment").gco()<CR>', map_opt)
+            map('n', 'gcO', '<CMD>lua require("Comment.comment").gcO()<CR>', map_opt)
+            map('n', 'gcA', '<CMD>lua require("Comment.comment").gcA()<CR>', map_opt)
         end
 
         -- Extended Mappings

--- a/lua/Comment/comment.lua
+++ b/lua/Comment/comment.lua
@@ -221,38 +221,38 @@ function C.setup(opts)
         if cfg.mappings.extended then
             local Op = require('Comment.opfunc')
 
-            function _G.___comment_ggt(vmode)
+            function C.ggt(vmode)
                 Op.opfunc(cfg, vmode, U.cmode.comment, U.ctype.line, U.cmotion._)
             end
-            function _G.___comment_ggtc(vmode)
+            function C.ggtc(vmode)
                 Op.opfunc(cfg, vmode, U.cmode.comment, U.ctype.line, U.cmotion.line)
             end
-            function _G.___comment_ggtb(vmode)
+            function C.ggtb(vmode)
                 Op.opfunc(cfg, vmode, U.cmode.comment, U.ctype.block, U.cmotion.line)
             end
 
-            function _G.___comment_glt(vmode)
+            function C.glt(vmode)
                 Op.opfunc(cfg, vmode, U.cmode.uncomment, U.ctype.line, U.cmotion._)
             end
-            function _G.___comment_gltc(vmode)
+            function C.gltc(vmode)
                 Op.opfunc(cfg, vmode, U.cmode.uncomment, U.ctype.line, U.cmotion.line)
             end
-            function _G.___comment_gltb(vmode)
+            function C.gltb(vmode)
                 Op.opfunc(cfg, vmode, U.cmode.uncomment, U.ctype.block, U.cmotion.line)
             end
 
             -- NORMAL mode extended
-            map('n', 'g>', '<CMD>lua ___comment_call("ggt")<CR>g@', map_opt)
-            map('n', 'g>c', '<CMD>lua ___comment_call("ggtc")<CR>g@$', map_opt)
-            map('n', 'g>b', '<CMD>lua ___comment_call("ggtb")<CR>g@$', map_opt)
+            map('n', 'g>', '<CMD>lua require("Comment.comment").call("ggt")<CR>g@', map_opt)
+            map('n', 'g>c', '<CMD>lua require("Comment.comment").call("ggtc")<CR>g@$', map_opt)
+            map('n', 'g>b', '<CMD>lua require("Comment.comment").call("ggtb")<CR>g@$', map_opt)
 
-            map('n', 'g<', '<CMD>lua ___comment_call("glt")<CR>g@', map_opt)
-            map('n', 'g<c', '<CMD>lua ___comment_call("gltc")<CR>g@$', map_opt)
-            map('n', 'g<b', '<CMD>lua ___comment_call("gltb")<CR>g@$', map_opt)
+            map('n', 'g<', '<CMD>lua require("Comment.comment").call("glt")<CR>g@', map_opt)
+            map('n', 'g<c', '<CMD>lua require("Comment.comment").call("gltc")<CR>g@$', map_opt)
+            map('n', 'g<b', '<CMD>lua require("Comment.comment").call("gltb")<CR>g@$', map_opt)
 
             -- VISUAL mode extended
-            map('x', 'g>', '<ESC><CMD>lua ___comment_ggt(vim.fn.visualmode())<CR>', map_opt)
-            map('x', 'g<', '<ESC><CMD>lua ___comment_glt(vim.fn.visualmode())<CR>', map_opt)
+            map('x', 'g>', '<ESC><CMD>lua require("Comment.comment").ggt(vim.fn.visualmode())<CR>', map_opt)
+            map('x', 'g<', '<ESC><CMD>lua require("Comment.comment").glt(vim.fn.visualmode())<CR>', map_opt)
         end
     end
 end

--- a/lua/Comment/init.lua
+++ b/lua/Comment/init.lua
@@ -1,4 +1,4 @@
-local C = require('Comment.comment')
+local C = require('Comment.api')
 
 return {
     setup = C.setup,

--- a/lua/Comment/init.lua
+++ b/lua/Comment/init.lua
@@ -5,7 +5,5 @@ return {
     toggle = C.toggle,
     comment = C.comment,
     uncomment = C.uncomment,
-    get_config = function()
-        return C.config
-    end,
+    get_config = C.get_config,
 }

--- a/lua/Comment/opfunc.lua
+++ b/lua/Comment/opfunc.lua
@@ -3,6 +3,8 @@ local A = vim.api
 
 local O = {}
 
+---@alias VMode 'line'|'char'|'v'|'V' Vim Mode. Read `:h map-operator`
+
 ---Comment context
 ---@class Ctx
 ---@field ctype CType
@@ -20,11 +22,11 @@ local O = {}
 ---@field range CRange
 
 ---Common operatorfunc callback
----@param vmode string VIM mode - line|char
----@param cfg Config Plugin config
----@param cmode CMode Comment mode
----@param ctype CType Type of the commentstring (line/block)
----@param cmotion CMotion Motion type
+---@param vmode VMode
+---@param cfg Config
+---@param cmode CMode
+---@param ctype CType
+---@param cmotion CMotion
 function O.opfunc(vmode, cfg, cmode, ctype, cmotion)
     -- comment/uncomment logic
     --

--- a/lua/Comment/opfunc.lua
+++ b/lua/Comment/opfunc.lua
@@ -249,7 +249,7 @@ function O.blockwise_x(p)
     return cmode
 end
 
----Toggle line comment with count
+---Toggle line comment with count i.e vim.v.count
 ---Example: `10gl` will comment 10 lines
 ---@param count integer Number of lines
 ---@param cfg Config

--- a/lua/Comment/opfunc.lua
+++ b/lua/Comment/opfunc.lua
@@ -20,12 +20,12 @@ local O = {}
 ---@field range CRange
 
 ---Common operatorfunc callback
----@param cfg Config Plugin config
 ---@param vmode string VIM mode - line|char
+---@param cfg Config Plugin config
 ---@param cmode CMode Comment mode
 ---@param ctype CType Type of the commentstring (line/block)
 ---@param cmotion CMotion Motion type
-function O.opfunc(cfg, vmode, cmode, ctype, cmotion)
+function O.opfunc(vmode, cfg, cmode, ctype, cmotion)
     -- comment/uncomment logic
     --
     -- 1. type == line

--- a/lua/Comment/opfunc.lua
+++ b/lua/Comment/opfunc.lua
@@ -251,9 +251,10 @@ end
 
 ---Toggle line comment with count
 ---Example: `10gl` will comment 10 lines
+---@param count integer Number of lines
 ---@param cfg Config
-function O.count(cfg)
-    local lines, range = U.get_count_lines(vim.v.count)
+function O.count(count, cfg)
+    local lines, range = U.get_count_lines(count)
 
     ---@type Ctx
     local ctx = {

--- a/lua/Comment/utils.lua
+++ b/lua/Comment/utils.lua
@@ -259,7 +259,7 @@ end
 ---@param lcs_esc string (Escaped) Left side of the commentstring
 ---@param rcs_esc string (Escaped) Right side of the commentstring
 ---@param pp string Padding pattern (@see U.get_padding)
----@return function function Function to call
+---@return fun(line: string):boolean
 function U.is_commented(lcs_esc, rcs_esc, pp)
     local ll = lcs_esc and '^%s*' .. lcs_esc .. pp or ''
     local rr = rcs_esc and pp .. rcs_esc .. '$' or ''

--- a/lua/Comment/utils.lua
+++ b/lua/Comment/utils.lua
@@ -11,35 +11,40 @@ local U = {}
 
 ---@alias CLines string[] List of lines inside the start and end index
 
----Comment modes
+---Comment modes - Can be manual or computed in operator-pending phase
 ---@class CMode
+---@field toggle number Toggle action
+---@field comment number Comment action
+---@field uncomment number Uncomment action
 U.cmode = {
     toggle = 0,
     comment = 1,
     uncomment = 2,
 }
 
----Comment types
+---Comment string types
 ---@class CType
+---@field line number Use linewise commentstring
+---@field block number Use blockwise commentstring
 U.ctype = {
     line = 1,
     block = 2,
 }
 
----Motion types
+---Comment motion types
 ---@class CMotion
+---@field _ number Compute from vim mode (@see VMode)
+---@field line number Line motion (ie. `gc2j`)
+---@field char number Character/left-right motion (ie. `gc2j`)
+---@field block number Visual operator-pending motion
+---@field v number Visual motion
+---@field V number Visual-line motion
 U.cmotion = {
-    ---Compute from vmode
     _ = 0,
-    ---line
     line = 1,
-    ---char/left-right
     char = 2,
-    ---visual operator-pending
     block = 3,
-    ---visual
     v = 4,
-    ---visual-line
     V = 5,
 }
 
@@ -116,7 +121,7 @@ function U.ignore(ln, pat)
 end
 
 ---Get region for vim mode
----@param vmode string VIM mode
+---@param vmode VMode
 ---@return CRange
 function U.get_region(vmode)
     local m = A.nvim_buf_get_mark
@@ -190,8 +195,8 @@ end
 ---1. pre_hook (optionally a string can be returned)
 ---2. ft_table (extra commentstring table in the plugin)
 ---3. commentstring (already set or added in pre_hook)
----@param cfg Config Context
----@param ctx Ctx Context
+---@param cfg Config
+---@param ctx Ctx
 ---@return string string Left side of the commentstring
 ---@return string string Right side of the commentstring
 function U.parse_cstr(cfg, ctx)


### PR DESCRIPTION
### Before
Previously, all those functions were kinda available via the global scope but there was no guarantee that those will stay that way.

### After
Now the objective is to properly expose them and treat them as the API of the plugin and remove all the global functions.