### PR TITLE
Update nvim-ts-context-commentstring example

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,9 +258,23 @@ There are two hook methods i.e `pre_hook` and `post_hook` which are called befor
     pre_hook = function(ctx)
         -- Only calculate commentstring for tsx filetypes
         if vim.bo.filetype == 'typescriptreact' then
+            local U = require('Comment.utils')
+
             -- Detemine whether to use linewise or blockwise commentstring
-            local type = ctx.ctype == require('Comment.utils').ctype.line and '__default' or '__multiline'
-            return require('ts_context_commentstring.internal').calculate_commentstring({ key = type })
+            local type = ctx.ctype == U.ctype.line and '__default' or '__multiline'
+
+            -- Determine the location where to calculate commentstring from
+            local location = nil
+            if ctx.ctype == U.ctype.block then
+                location = require('ts_context_commentstring.utils').get_cursor_location()
+            elseif ctx.cmotion == U.cmotion.v or ctx.cmotion == U.cmotion.V then
+                location = require('ts_context_commentstring.utils').get_visual_start_location()
+            end
+
+            return require('ts_context_commentstring.internal').calculate_commentstring({
+                key = type,
+                location = location,
+            })
         end
     end,
 }


### PR DESCRIPTION
Hey! `nvim-ts-context-commentstring` got a new configuration parameter for `calculate_commentstring` which allows configuring the location where the `commentstring` is calculated from. By default it is the start of the cursor's line, but we can make it smarter based on if the user is visually selecting something or is performing a motion.

This helps in this case in a Vue file for example:

```vue
                v---------v injected TypeScript
<button @click="handleClick">Hello</button>
                   ^ cursor
```

Performing `gciw` would now correctly result in the following:

```vue
<button @click="/* handleClick */">Hello</button>
```

Instead of:

```vue
<button @click="<!-- handleClick -->">Hello</button>
```

Related PR: https://github.com/JoosepAlviste/nvim-ts-context-commentstring/pull/28

Also fixes this case: https://github.com/numToStr/Comment.nvim/issues/10#issuecomment-945556118