### PR TITLE
chore: refactor `utils.get_lines`

### DIFF
--- a/lua/Comment/opfunc.lua
+++ b/lua/Comment/opfunc.lua
@@ -46,8 +46,7 @@ function O.opfunc(cfg, vmode, cmode, ctype, cmotion)
 
     cmotion = cmotion == U.cmotion._ and U.cmotion[vmode] or cmotion
 
-    local lines, range = U.get_lines(vmode, ctype)
-
+    local range = U.get_region(vmode)
     local same_line = range.srow == range.erow
     local partial_block = cmotion == U.cmotion.char or cmotion == U.cmotion.v
     local block_x = partial_block and same_line
@@ -61,6 +60,7 @@ function O.opfunc(cfg, vmode, cmode, ctype, cmotion)
     }
 
     local lcs, rcs = U.parse_cstr(cfg, ctx)
+    local lines = U.get_lines(range)
 
     if block_x then
         ctx.cmode = O.blockwise_x({
@@ -173,16 +173,17 @@ end
 ---@return integer CMode
 function O.blockwise(p, partial)
     -- Block wise, only when there are more than 1 lines
-    local sln, eln = p.lines[1], p.lines[2]
+    local sln, eln = p.lines[1], p.lines[#p.lines]
     local lcs_esc, rcs_esc = U.escape(p.lcs), U.escape(p.rcs)
     local padding, pp = U.get_padding(p.cfg.padding)
 
     -- These string should be checked for comment/uncomment
-    local sln_check = sln
-    local eln_check = eln
+    local sln_check, eln_check
     if partial then
         sln_check = sln:sub(p.range.scol + 1)
         eln_check = eln:sub(0, p.range.ecol + 1)
+    else
+        sln_check, eln_check = sln, eln
     end
 
     -- If given mode is toggle then determine whether to comment or not

--- a/lua/Comment/utils.lua
+++ b/lua/Comment/utils.lua
@@ -124,11 +124,9 @@ function U.get_region(vmode)
     local sln, eln
 
     if vmode:match('[vV]') then
-        sln = m(buf, '<')
-        eln = m(buf, '>')
+        sln, eln = m(buf, '<'), m(buf, '>')
     else
-        sln = m(buf, '[')
-        eln = m(buf, ']')
+        sln, eln = m(buf, '['), m(buf, ']')
     end
 
     return {

--- a/lua/Comment/utils.lua
+++ b/lua/Comment/utils.lua
@@ -158,29 +158,15 @@ function U.get_count_lines(count)
 end
 
 ---Get lines from a NORMAL/VISUAL mode
----@param vmode string VIM mode
----@param ctype CType
+---@param range CRange
 ---@return CLines
----@return CRange
-function U.get_lines(vmode, ctype)
-    local range = U.get_region(vmode)
-
+function U.get_lines(range)
     -- If start and end is same, then just return the current line
-    local lines
     if range.srow == range.erow then
-        lines = { A.nvim_get_current_line() }
-    elseif ctype == U.ctype.block then
-        -- In block we only need the starting and endling line
-        lines = {
-            A.nvim_buf_get_lines(0, range.srow - 1, range.srow, false)[1],
-            A.nvim_buf_get_lines(0, range.erow - 1, range.erow, false)[1],
-        }
-    else
-        -- decrementing `scol` by one bcz marks are 1 based but lines are 0 based
-        lines = A.nvim_buf_get_lines(0, range.srow - 1, range.erow, false)
+        return { A.nvim_get_current_line() }
     end
 
-    return lines, range
+    return A.nvim_buf_get_lines(0, range.srow - 1, range.erow, false)
 end
 
 ---Validates and unwraps the given commentstring


### PR DESCRIPTION
Resolves #70 

Now you can do this

```lua
require('Comment').setup({
    pre_hook = function(ctx)
        local lines = require('Comment.utils').get_lines(ctx.range)
        local srow = ctx.range.erow
        vim.api.nvim_buf_set_lines(0, srow, srow, false, lines)
    end,
    post_hook = function(ctx)
        local U = require('Comment.utils')
        local srow = ctx.range.erow
        local erow = srow + 1
        local line = U.get_lines({ srow = srow, erow = erow })
        local _, col = U.grab_indent(line[1])
        vim.api.nvim_win_set_cursor(0, { erow, col })
    end,
})
````

https://user-images.githubusercontent.com/24727447/142718954-5507daa1-a0c3-4f02-94c5-c407f43a74e4.mp4



