### PR TITLE
BREAKING: remove redundant range(s) args from `post_hook`

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,13 +243,15 @@ This plugin also has the basic support of treesitter for calculating `commentstr
 1. No `jsx/tsx` support. Its implementation was quite complicated.
 2. Invalid comment on the region where one language ends and the other starts. [Read more](https://github.com/numToStr/Comment.nvim/pull/62#issuecomment-972790418)
 
-For more advance use cases you should use [nvim-ts-context-commentstring](https://github.com/JoosepAlviste/nvim-ts-context-commentstring). See [hooks](#hooks) section.
+For more advance use cases you should use [nvim-ts-context-commentstring](https://github.com/JoosepAlviste/nvim-ts-context-commentstring). See [`pre_hook`](#pre-hook) section for the integration.
 
 <a id="hooks"></a>
 
 ### 🎣 Hooks
 
 There are two hook methods i.e `pre_hook` and `post_hook` which are called before comment and after comment respectively. Both should be provided during [`setup()`](#setup).
+
+<a id="pre-hook"></a>
 
 - `pre_hook` - This method is called with a [`ctx`](#comment-context) argument before comment/uncomment is started. It can be used to return a custom `commentstring` which will be used for comment/uncomment the lines. You can use something like [nvim-ts-context-commentstring](https://github.com/JoosepAlviste/nvim-ts-context-commentstring) to compute the commentstring using treesitter.
 
@@ -282,7 +284,9 @@ There are two hook methods i.e `pre_hook` and `post_hook` which are called befor
 }
 ```
 
-- `post_hook` - This method is called after commenting is done. It receives the same [`ctx`](#comment-context) argument
+<a id="post-hook"></a>
+
+- `post_hook` - This method is called after commenting is done. It receives the same [`ctx`](#comment-context) argument as [`pre_hook`](#pre_hook).
 
 ```lua
 {
@@ -299,8 +303,8 @@ There are two hook methods i.e `pre_hook` and `post_hook` which are called befor
 
 The `post_hook` can be implemented to cover some niche use cases like the following:
 
-- Using newlines instead of padding e.g. for commenting out code in C with `#if 0`. You can find an example [here](https://github.com/numToStr/Comment.nvim/issues/38#issuecomment-945082507).
-- Duplicating the commented block and moving the cursor the next block. See [this](https://github.com/numToStr/Comment.nvim/issues/70)
+- Using newlines instead of padding e.g. for commenting out code in C with `#if 0`. See an example [here](https://github.com/numToStr/Comment.nvim/issues/38#issuecomment-945082507).
+- Duplicating the commented block (using `pre_hook`) and moving the cursor to the next block (using `post_hook`). See [this](https://github.com/numToStr/Comment.nvim/issues/70).
 
 > NOTE: When pressing `gc`, `gb` and friends, `cmode` (Comment mode) inside `pre_hook` will always be toggle because when pre-hook is called, in that moment we don't know whether `gc` or `gb` will comment or uncomment the lines. But luckily, we do know this before `post_hook` and this will always receive either comment or uncomment status
 

--- a/README.md
+++ b/README.md
@@ -282,33 +282,13 @@ There are two hook methods i.e `pre_hook` and `post_hook` which are called befor
 }
 ```
 
-Also, you can set the `commentstring` from here but [**i won't recommend it**](#commentstring-caveat) for now.
+- `post_hook` - This method is called after commenting is done. It receives the same [`ctx`](#comment-context) argument
 
 ```lua
 {
     ---@param ctx Ctx
-    pre_hook = function(ctx)
-        -- Only update commentstring for tsx filetypes
-        if vim.bo.filetype == 'typescriptreact' then
-            require('ts_context_commentstring.internal').update_commentstring()
-        end
-    end
-}
-```
-
-- `post_hook` - This method is called after commenting is done. It receives the same 1) [`ctx`](#comment-context), the lines range 2) `start_row` 3) `end_row` 4) `start_col` 5) `end_col`.
-
-> NOTE: If [methods](#methods) are used, then `post_hook` will receives only two arguments 1) [`ctx`](#comment-context) and 2) `-1` indicating the current line
-
-```lua
-{
-    ---@param ctx Ctx
-    ---@param start_row integar
-    ---@param end_row integar
-    ---@param start_col integar
-    ---@param end_col integar
-    post_hook = function(ctx, start_row, end_row, start_col, end_col)
-        if start_row == -1 then
+    post_hook = function(ctx)
+        if ctx.range.srow == ctx.range.srow then
             -- do something with the current line
         else
             -- do something with lines range
@@ -317,7 +297,10 @@ Also, you can set the `commentstring` from here but [**i won't recommend it**](#
 }
 ```
 
-The `post_hook` can be implemented to use newlines instead of padding e.g. for commenting out code in C with `#if 0`. You can find an example [here](https://github.com/numToStr/Comment.nvim/issues/38#issuecomment-945082507).
+The `post_hook` can be implemented to cover some niche use cases like the following:
+
+- Using newlines instead of padding e.g. for commenting out code in C with `#if 0`. You can find an example [here](https://github.com/numToStr/Comment.nvim/issues/38#issuecomment-945082507).
+- Duplicating the commented block and moving the cursor the next block. See [this](https://github.com/numToStr/Comment.nvim/issues/70)
 
 > NOTE: When pressing `gc`, `gb` and friends, `cmode` (Comment mode) inside `pre_hook` will always be toggle because when pre-hook is called, in that moment we don't know whether `gc` or `gb` will comment or uncomment the lines. But luckily, we do know this before `post_hook` and this will always receive either comment or uncomment status
 
@@ -423,10 +406,17 @@ The following object is provided as an argument to `pre_hook` and `post_hook` fu
 ```lua
 ---Comment context
 ---@class Ctx
----@field lang string: The name of the language where the cursor is
 ---@field ctype CType
 ---@field cmode CMode
 ---@field cmotion CMotion
+---@field range CRange
+
+---Range of the selection that needs to be commented
+---@class CRange
+---@field srow number Starting row
+---@field scol number Starting column
+---@field erow number Ending row
+---@field ecol number Ending column
 ```
 
 `CType` (Comment type), `CMode` (Comment mode) and `CMotion` (Comment motion) all of them are exported from the plugin's utils for reuse
@@ -445,7 +435,7 @@ There are multiple ways to contribute reporting/fixing bugs, feature requests. Y
 
 ### 💐 Credits
 
-- [tcomment]() - To be with me forever and motivated me to write this.
+- [tcomment](https://github.com/tomtom/tcomment_vim) - To be with me forever and motivated me to write this.
 - [nvim-comment](https://github.com/terrortylor/nvim-comment) - Little and less powerful cousin. Also I took some code from it.
 - [kommentary](https://github.com/b3nj5m1n/kommentary) - Nicely done plugin but lacks some features. But it helped me to design this plugin.
 

--- a/lua/Comment/comment.lua
+++ b/lua/Comment/comment.lua
@@ -25,7 +25,7 @@ function C.comment()
 
         local padding, _ = U.get_padding(C.config.padding)
         A.nvim_set_current_line(U.comment_str(line, lcs, rcs, padding))
-        U.is_fn(C.config.post_hook, ctx, -1)
+        U.is_fn(C.config.post_hook, ctx)
     end
 end
 
@@ -52,7 +52,7 @@ function C.uncomment()
             A.nvim_set_current_line(U.uncomment_str(line, lcs_esc, rcs_esc, pp))
         end
 
-        U.is_fn(C.config.post_hook, ctx, -1)
+        U.is_fn(C.config.post_hook, ctx)
     end
 end
 
@@ -84,7 +84,7 @@ function C.toggle()
             ctx.cmode = U.cmode.comment
         end
 
-        U.is_fn(C.config.post_hook, ctx, -1)
+        U.is_fn(C.config.post_hook, ctx)
     end
 end
 

--- a/lua/Comment/extra.lua
+++ b/lua/Comment/extra.lua
@@ -31,7 +31,7 @@ local function ins_on_line(count, ctype, cfg)
     A.nvim_buf_set_lines(0, srow, srow, false, { ll .. if_rcs })
     local erow, ecol = srow + 1, #ll - 1
     U.move_n_insert(erow, ecol)
-    U.is_fn(cfg.post_hook, ctx, srow, erow, col, ecol)
+    U.is_fn(cfg.post_hook, ctx)
 end
 
 ---Add a comment below the current line and goes to INSERT mode
@@ -79,7 +79,7 @@ function E.norm_A(ctype, cfg)
     local erow, ecol = srow - 1, #ll - 1
     A.nvim_buf_set_lines(0, erow, srow, false, { ll .. if_rcs })
     U.move_n_insert(srow, ecol)
-    U.is_fn(cfg.post_hook, ctx, srow, erow, scol, ecol)
+    U.is_fn(cfg.post_hook, ctx)
 end
 
 return E

--- a/lua/Comment/opfunc.lua
+++ b/lua/Comment/opfunc.lua
@@ -101,8 +101,7 @@ function O.opfunc(cfg, vmode, cmode, ctype, cmotion)
         cfg.___pos = nil
     end
 
-    -- TODO: Remove the range arguments in next update
-    U.is_fn(cfg.post_hook, ctx, range.srow, range.erow, range.scol, range.ecol)
+    U.is_fn(cfg.post_hook, ctx)
 end
 
 ---Linewise commenting
@@ -272,8 +271,7 @@ function O.count(cfg)
         range = range,
     })
 
-    -- TODO: Remove the range arguments in next update
-    U.is_fn(cfg.post_hook, ctx, range.srow, range.erow)
+    U.is_fn(cfg.post_hook, ctx)
 end
 
 return O


### PR DESCRIPTION
Now range can be accessed via `ctx.range`