### PR TITLE
docs: gcb -> gbc

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Following are the **default** config for the [`setup()`](#setup). If you want to
     ---@type table
     mappings = {
         ---operator-pending mapping
-        ---Includes `gcc`, `gcb`, `gc[count]{motion}` and `gb[count]{motion}`
+        ---Includes `gcc`, `gbc`, `gc[count]{motion}` and `gb[count]{motion}`
         ---NOTE: These mappings can be changed individually by `opleader` and `toggler` config
         basic = true,
         ---extra mapping

--- a/lua/Comment/api.lua
+++ b/lua/Comment/api.lua
@@ -15,7 +15,7 @@ local A = vim.api
 ---Whether to create basic (operator-pending) and extended mappings
 ---@class Mappings
 ---Enable operator-pending mapping
----Includes `gcc`, `gcb`, `gc[count]{motion}` and `gb[count]{motion}`
+---Includes `gcc`, `gbc`, `gc[count]{motion}` and `gb[count]{motion}`
 ---NOTE: These mappings can be changed individually by `opleader` and `toggler` config
 ---@field basic boolean
 ---Enable extra mapping


### PR DESCRIPTION
`gcb` is `gc` followed by a motion `b`, while `gbc` is block-commenting
the whole line.