### PR TITLE
Use mode 'ni' for nvim_feedkeys

### DIFF
--- a/lua/Comment/utils.lua
+++ b/lua/Comment/utils.lua
@@ -88,7 +88,7 @@ end
 ---@param col number Ending column
 function U.move_n_insert(row, col)
     A.nvim_win_set_cursor(0, { row, col })
-    A.nvim_feedkeys('a', 'n', true)
+    A.nvim_feedkeys('a', 'ni', true)
 end
 
 ---Convert the string to a escaped string, if given


### PR DESCRIPTION
When mode is 'n' then the keys are _appended_ to the typeahead buffer,
which can add them _after_ other keys in a mapping. Using 'ni' instead
inserts them, so that keys later in the binding remain later in the
buffer.

This allows mappings such as:

`"gcATODO<ESC>"`

to work as expected.

Fixes #88