### PR TITLE
feat: add `count` support for `gbc`

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 - Prefers single-line/linewise comments
 - Supports line (`//`) and block (`/* */`) comments
 - Dot (`.`) repeat support for `gcc`, `gbc` and friends
-- Count support (`[count]gcc` only)
+- Count support for `[count]gcc` and `[count]gbc`
 - Left-right (`gcw` `gc$`) and Up-Down (`gc2j` `gc4k`) motions
 - Use with text-objects (`gci{` `gbat`)
 - Supports pre and post hooks
@@ -150,14 +150,15 @@ These mappings are enabled by default. (config: `mappings.basic`)
 ```help
 `gcc` - Toggles the current line using linewise comment
 `gbc` - Toggles the current line using blockwise comment
-`[count]gcc` - Toggles the number of line given as a prefix-count
+`[count]gcc` - Toggles the number of line given as a prefix-count using linewise
+`[count]gbc` - Toggles the number of line given as a prefix-count using blockwise
 `gc[count]{motion}` - (Op-pending) Toggles the region using linewise comment
 `gb[count]{motion}` - (Op-pending) Toggles the region using linewise comment
 ```
 
 <a id="count-prefix">
 
-> NOTE: Dot repeat is not supported with `[count]gcc`
+> NOTE: Dot repeat is not supported with `[count]gcc` and `[count]gbc`
 
 - VISUAL mode
 

--- a/doc/API.md
+++ b/doc/API.md
@@ -46,6 +46,10 @@ require('Comment.api').toggle_current_blockwise_op(vmode, cfg)
 ---@param vmode VMode
 ---@param cfg? Config
 require('Comment.api').toggle_blockwise_op(vmode, cfg)
+
+---Toggle blockwise-comment over multiple lines using `vim.v.count`
+---@param cfg? Config
+require('Comment.api').toggle_blockwise_count(cfg)
 ```
 
 ### Extra

--- a/lua/Comment/api.lua
+++ b/lua/Comment/api.lua
@@ -35,7 +35,7 @@ end
 ---Toggle linewise-comment over multiple lines using `vim.v.count`
 ---@param cfg? Config
 function C.toggle_linewise_count(cfg)
-    Op.count(vim.v.count, cfg or Config:get())
+    Op.count(vim.v.count, cfg or Config:get(), U.ctype.line)
 end
 
 --######### BLOCKWISE #########--
@@ -58,6 +58,12 @@ end
 ---@param cfg? Config
 function C.toggle_blockwise_op(vmode, cfg)
     Op.opfunc(vmode, cfg or Config:get(), U.cmode.toggle, U.ctype.block, U.cmotion._)
+end
+
+---Toggle blockwise-comment over multiple lines using `vim.v.count`
+---@param cfg? Config
+function C.toggle_blockwise_count(cfg)
+    Op.count(vim.v.count, cfg or Config:get(), U.ctype.block)
 end
 
 ---------------------------------------
@@ -203,18 +209,19 @@ function C.setup(config)
 
         -- Basic Mappings
         if cfg.mappings.basic then
+            local expr = { noremap = true, silent = true, expr = true }
             -- NORMAL mode mappings
             map(
                 'n',
                 cfg.toggler.line,
                 [[v:count == 0 ? '<CMD>lua require("Comment.api").call("toggle_current_linewise_op")<CR>g@$' : '<CMD>lua require("Comment.api").toggle_linewise_count()<CR>']],
-                { noremap = true, silent = true, expr = true }
+                expr
             )
             map(
                 'n',
                 cfg.toggler.block,
-                '<CMD>lua require("Comment.api").call("toggle_current_blockwise_op")<CR>g@$',
-                map_opt
+                [[v:count == 0 ? '<CMD>lua require("Comment.api").call("toggle_current_blockwise_op")<CR>g@$' : '<CMD>lua require("Comment.api").toggle_blockwise_count()<CR>']],
+                expr
             )
             map('n', cfg.opleader.line, '<CMD>lua require("Comment.api").call("toggle_linewise_op")<CR>g@', map_opt)
             map('n', cfg.opleader.block, '<CMD>lua require("Comment.api").call("toggle_blockwise_op")<CR>g@', map_opt)

--- a/lua/Comment/opfunc.lua
+++ b/lua/Comment/opfunc.lua
@@ -64,33 +64,22 @@ function O.opfunc(vmode, cfg, cmode, ctype, cmotion)
     local lcs, rcs = U.parse_cstr(cfg, ctx)
     local lines = U.get_lines(range)
 
+    ---@type OpFnParams
+    local params = {
+        cfg = cfg,
+        cmode = cmode,
+        lines = lines,
+        lcs = lcs,
+        rcs = rcs,
+        range = range,
+    }
+
     if block_x then
-        ctx.cmode = O.blockwise_x({
-            cfg = cfg,
-            cmode = cmode,
-            lines = lines,
-            lcs = lcs,
-            rcs = rcs,
-            range = range,
-        })
+        ctx.cmode = O.blockwise_x(params)
     elseif ctype == U.ctype.block and not same_line then
-        ctx.cmode = O.blockwise({
-            cfg = cfg,
-            cmode = cmode,
-            lines = lines,
-            lcs = lcs,
-            rcs = rcs,
-            range = range,
-        }, partial_block)
+        ctx.cmode = O.blockwise(params, partial_block)
     else
-        ctx.cmode = O.linewise({
-            cfg = cfg,
-            cmode = cmode,
-            lines = lines,
-            lcs = lcs,
-            rcs = rcs,
-            range = range,
-        })
+        ctx.cmode = O.linewise(params)
     end
 
     -- We only need to restore cursor if both sticky and position are available
@@ -253,26 +242,34 @@ end
 ---Example: `10gl` will comment 10 lines
 ---@param count integer Number of lines
 ---@param cfg Config
-function O.count(count, cfg)
+---@param ctype CType
+function O.count(count, cfg, ctype)
     local lines, range = U.get_count_lines(count)
 
     ---@type Ctx
     local ctx = {
         cmode = U.cmode.toggle,
         cmotion = U.cmotion.line,
-        ctype = U.ctype.line,
+        ctype = ctype,
         range = range,
     }
     local lcs, rcs = U.parse_cstr(cfg, ctx)
 
-    ctx.cmode = O.linewise({
+    ---@type OpFnParams
+    local params = {
         cfg = cfg,
         cmode = ctx.cmode,
         lines = lines,
         lcs = lcs,
         rcs = rcs,
         range = range,
-    })
+    }
+
+    if ctype == U.ctype.block then
+        ctx.cmode = O.blockwise(params)
+    else
+        ctx.cmode = O.linewise(params)
+    end
 
     U.is_fn(cfg.post_hook, ctx)
 end


### PR DESCRIPTION
Now you can press any number followed by `gbc`. For example:

`4gbc` -> toggle blockwise comment on 4 lines (including current line)

---

Closes #95 