### PR TITLE
Always operate on at least one line

### DIFF
--- a/lua/Comment/opfunc.lua
+++ b/lua/Comment/opfunc.lua
@@ -244,7 +244,7 @@ end
 ---@param cfg Config
 ---@param ctype CType
 function O.count(count, cfg, ctype)
-    local lines, range = U.get_count_lines(count)
+    local lines, range = U.get_count_lines(count == 0 and 1 or count)
 
     ---@type Ctx
     local ctx = {


### PR DESCRIPTION
I'm coming from nerdcommenter and want a very simple setup.

Essentially I want a single key binding that will toggle the current line or a number of lines

I have the following keymap

```lua
keymap('n', '<leader>c', '<CMD>lua require("Comment.api").toggle_linewise_count()<CR>', opts)
```
this lets me use
* <leader>c to comment the current line
* 4<leader>c to comment f lines

This patch allows the first version to work.

This feels a bit hacky and there is probably a better way to achieve this?