### PR TITLE
feat: add `svelte` support

### DIFF
--- a/lua/Comment/ft.lua
+++ b/lua/Comment/ft.lua
@@ -61,6 +61,7 @@ local L = {
     scala = { M.cxx_l, M.cxx_b },
     sh = { M.hash },
     sql = { M.dash, M.cxx_b },
+    svelte = { M.html_b, M.html_b },
     swift = { M.cxx_l, M.cxx_b },
     sxhkdrc = { M.hash },
     teal = { M.dash, M.dash_bracket },


### PR DESCRIPTION
This fixes comments in svelte html context. Scripts seem to work already as well as line comments in css. However, block comments in css (inside a svelte file) do not use the correct commentstring.