### PR TITLE
feat: add ruby support

### DIFF
--- a/lua/Comment/ft.lua
+++ b/lua/Comment/ft.lua
@@ -57,6 +57,7 @@ local L = {
     python = { M.hash }, -- Python doesn't have block comments
     php = { M.cxx_l, M.cxx_b },
     readline = { M.hash },
+    ruby = { M.hash },
     rust = { M.cxx_l, M.cxx_b },
     scala = { M.cxx_l, M.cxx_b },
     sh = { M.hash },


### PR DESCRIPTION
Noticed some issues with trying to comment out a vanilla Ruby file:

![Screen Shot 2022-01-25 at 19 43 55](https://user-images.githubusercontent.com/9512444/151048227-970eca17-4a55-4619-8d62-530ec8749093.gif)