### PR TITLE
Don't add space in front of comment on empty lines with `insert_eol()`

### DIFF
--- a/lua/Comment/extra.lua
+++ b/lua/Comment/extra.lua
@@ -66,27 +66,26 @@ function E.insert_eol(ctype, cfg)
     local line = A.nvim_get_current_line()
     local padding = U.get_padding(cfg.padding)
 
-    -- NOTE:
-    -- 1. If the line is empty, don't put any space in front of the comment
-    -- 2. Python is the only language that recommends 2 spaces between the statement and the comment
-    -- 3. Other than that, I am assuming that the users wants a space b/w the end of line and start of the comment
-    local space
     if line:match('^$') then
-        space = ''
-    elseif vim.bo.filetype == 'python' then
-        space = '  '
+        -- If line is empty, start comment at the correct indentation level
+        A.nvim_buf_set_lines(0, srow - 1, srow, false, { lcs .. padding })
+        vim.cmd('normal! ==')
+        U.move_n_insert(srow, A.nvim_get_current_line():len())
     else
-        space = ' '
+        -- NOTE:
+        -- 1. Python is the only language that recommends 2 spaces between the statement and the comment
+        -- 2. Other than that, I am assuming that the users wants a space b/w the end of line and start of the comment
+        local space = vim.bo.filetype == 'python' and '  ' or ' '
+        local ll = line .. space .. lcs .. padding
+
+        -- We need RHS of cstr, if we are doing block comments or if RHS exists
+        -- because even in line comment RHS do exists for some filetypes like jsx_element, ocaml
+        local if_rcs = (ctype == U.ctype.block or rcs) and padding .. rcs or ''
+
+        local erow, ecol = srow - 1, #ll - 1
+        A.nvim_buf_set_lines(0, erow, srow, false, { ll .. if_rcs })
+        U.move_n_insert(srow, ecol)
     end
-    local ll = line .. space .. lcs .. padding
-
-    -- We need RHS of cstr, if we are doing block comments or if RHS exists
-    -- because even in line comment RHS do exists for some filetypes like jsx_element, ocaml
-    local if_rcs = (ctype == U.ctype.block or rcs) and padding .. rcs or ''
-
-    local erow, ecol = srow - 1, #ll - 1
-    A.nvim_buf_set_lines(0, erow, srow, false, { ll .. if_rcs })
-    U.move_n_insert(srow, ecol)
     U.is_fn(cfg.post_hook, ctx)
 end
 

--- a/lua/Comment/extra.lua
+++ b/lua/Comment/extra.lua
@@ -67,9 +67,17 @@ function E.insert_eol(ctype, cfg)
     local padding = U.get_padding(cfg.padding)
 
     -- NOTE:
-    -- 1. Python is the only language that recommends 2 spaces between the statement and the comment
-    -- 2. Other than that, I am assuming that the users wants a space b/w the end of line and start of the comment
-    local space = vim.bo.filetype == 'python' and '  ' or ' '
+    -- 1. If the line is empty, don't put any space in front of the comment
+    -- 2. Python is the only language that recommends 2 spaces between the statement and the comment
+    -- 3. Other than that, I am assuming that the users wants a space b/w the end of line and start of the comment
+    local space
+    if line:match('^$') then
+        space = ''
+    elseif vim.bo.filetype == 'python' then
+        space = '  '
+    else
+        space = ' '
+    end
     local ll = line .. space .. lcs .. padding
 
     -- We need RHS of cstr, if we are doing block comments or if RHS exists


### PR DESCRIPTION
`insert_eol()` used to always add one space in front of the comment. In this PR it checks if the line is empty, and if it is, no space is added in front of the comment.

Here's an example:

```lua
1. local value = 1
2.
3. print(value)
```

Before, pressing `gcA` with cursor on line 2 and then typing the word `comment` would result in the following:

```lua
1. local value = 1
2.  -- comment
3. print(value)
```

Now it will look like this:

```lua
1. local value = 1
2. -- comment
3. print(value)
```

An even neater solution would be to use `vim.fn.indent('.')` to calculate the indent level, which would always give the comment a correct indent level in case the line is in an indented environment, for instance inside a function definition or something like that. However I couldn't figure out how to get this to work with tabs if `noexpandtab` is set. `vim.fn.indent('.')` seems to always return the number of spaces (based on `tabstop`).

Do you have an idea of how to get it to work with tabs as well?