### PR TITLE
change: use starting column when using `*_current_*` apis

### DIFF
--- a/lua/Comment/utils.lua
+++ b/lua/Comment/utils.lua
@@ -116,8 +116,8 @@ end
 ---@return CRange
 function U.get_region(vmode)
     if not vmode then
-        local row, col = unpack(A.nvim_win_get_cursor(0))
-        return { srow = row, scol = col, erow = row, ecol = col }
+        local row = unpack(A.nvim_win_get_cursor(0))
+        return { srow = row, scol = 0, erow = row, ecol = 0 }
     end
 
     local m = A.nvim_buf_get_mark


### PR DESCRIPTION
When using an API function on a single line with embedded code, the commentstring detected using treesitter is not correct when using the cursor position. To fix this, I am changing the column position being parsed when vmode is set to nil.