### PR TITLE
chore!: refactoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,10 +424,10 @@ The following object is provided as an argument to `pre_hook` and `post_hook` fu
 
 ---Range of the selection that needs to be commented
 ---@class CommentRange
----@field srow number Starting row
----@field scol number Starting column
----@field erow number Ending row
----@field ecol number Ending column
+---@field srow integer Starting row
+---@field scol integer Starting column
+---@field erow integer Ending row
+---@field ecol integer Ending column
 ```
 
 `CommentType`, `CommentMode` and `CommentMotion` all of them are exported from the plugin's utils for reuse

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ lua require('Comment').setup()
 
 First you need to call the `setup()` method to create the default mappings.
 
-> NOTE: If you are facing **Keybindings are mapped but they are not working** issue then please try [this](https://github.com/numToStr/Comment.nvim/issues/115#issuecomment-1032290098)
+> **Note** - If you are facing **Keybindings are mapped but they are not working** issue then please try [this](https://github.com/numToStr/Comment.nvim/issues/115#issuecomment-1032290098)
 
 - Lua
 
@@ -243,6 +243,8 @@ This plugin has native **treesitter** support for calculating `commentstring` wh
 
 For advance use cases, use [nvim-ts-context-commentstring](https://github.com/JoosepAlviste/nvim-ts-context-commentstring). See [`pre_hook`](#pre-hook) section for the integration.
 
+> **Note** - This plugin does not depend on [nvim-treesitter](https://github.com/nvim-treesitter/nvim-treesitter) however it is recommended in order to easily install tree-sitter parsers.
+
 <a id="hooks"></a>
 
 ### 🎣 Hooks
@@ -355,6 +357,8 @@ vim.api.nvim_command('set commentstring=//%s')
 
 > Run `:h commentstring` for more help
 
+<a id="ft-lua"></a>
+
 2. You can also use this plugin interface to store both line and block commentstring for the filetype. You can treat this as a more powerful version of the `commentstring`
 
 ```lua
@@ -394,7 +398,7 @@ Although, `Comment.nvim` supports neovim's `commentstring` but unfortunately it 
 
 - [`pre_hook`](#hooks) - If a string is returned from this method then it will be used for commenting.
 
-- [`ft_table`](#languages) - If the current filetype is found in the table, then the string there will be used.
+- [`ft.lua`](#ft-lua) - If the current filetype is found in the table, then the string there will be used.
 
 - `commentstring` - Neovim's native commentstring for the filetype
 

--- a/lua/Comment/api.lua
+++ b/lua/Comment/api.lua
@@ -197,7 +197,7 @@ end
 ---@param opmode OpMode
 ---@param cfg? CommentConfig
 function api.uncomment_current_blockwise_op(opmode, cfg)
-    Op.opfunc(opmode, cfg, U.cmode.uncomment, U.ctype.block, U.cmotion.line)
+    Op.opfunc(opmode, cfg or Config:get(), U.cmode.uncomment, U.ctype.block, U.cmotion.line)
 end
 
 --==========================================

--- a/lua/Comment/config.lua
+++ b/lua/Comment/config.lua
@@ -44,8 +44,8 @@
 ---@private
 ---@class RootConfig
 ---@field config CommentConfig
----@field position number[] To be used to restore cursor position
----@field count number Helps with dot-repeat support for count prefix
+---@field position integer[] To be used to restore cursor position
+---@field count integer Helps with dot-repeat support for count prefix
 local Config = {
     state = {},
     config = {
@@ -88,6 +88,7 @@ function Config:get()
     return self.config
 end
 
+---@export ft
 return setmetatable(Config, {
     __index = function(this, k)
         return this.state[k]

--- a/lua/Comment/extra.lua
+++ b/lua/Comment/extra.lua
@@ -6,7 +6,7 @@ local A = vim.api
 local extra = {}
 
 ---@param count number Line index
----@param ctype CommentType
+---@param ctype number See |CommentType|
 ---@param cfg CommentConfig
 local function ins_on_line(count, ctype, cfg)
     local row, col = unpack(A.nvim_win_get_cursor(0))
@@ -37,21 +37,21 @@ local function ins_on_line(count, ctype, cfg)
 end
 
 ---Add a comment below the current line and goes to INSERT mode
----@param ctype CommentType
+---@param ctype number See |CommentType|
 ---@param cfg CommentConfig
 function extra.insert_below(ctype, cfg)
     ins_on_line(0, ctype, cfg)
 end
 
 ---Add a comment above the current line and goes to INSERT mode
----@param ctype CommentType
+---@param ctype number See |CommentType|
 ---@param cfg CommentConfig
 function extra.insert_above(ctype, cfg)
     ins_on_line(-1, ctype, cfg)
 end
 
 ---Add a comment at the end of current line and goes to INSERT mode
----@param ctype CommentType
+---@param ctype number See |CommentType|
 ---@param cfg CommentConfig
 function extra.insert_eol(ctype, cfg)
     local srow, scol = unpack(A.nvim_win_get_cursor(0))

--- a/lua/Comment/extra.lua
+++ b/lua/Comment/extra.lua
@@ -83,7 +83,7 @@ function extra.insert_eol(ctype, cfg)
     local ecol
     if U.is_empty(line) then
         -- If line is empty, start comment at the correct indentation level
-        A.nvim_buf_set_lines(0, srow - 1, srow, false, { lcs .. padding .. if_rcs })
+        A.nvim_set_current_line(lcs .. padding .. if_rcs)
         A.nvim_command('normal! ==')
         ecol = #A.nvim_get_current_line() - #if_rcs - 1
     else
@@ -92,9 +92,8 @@ function extra.insert_eol(ctype, cfg)
         -- 2. Other than that, I am assuming that the users wants a space b/w the end of line and start of the comment
         local space = vim.bo.filetype == 'python' and '  ' or ' '
         local ll = line .. space .. lcs .. padding
-
+        A.nvim_set_current_line(ll .. if_rcs)
         ecol = #ll - 1
-        A.nvim_buf_set_lines(0, srow - 1, srow, false, { ll .. if_rcs })
     end
 
     move_n_insert(srow, ecol)

--- a/lua/Comment/extra.lua
+++ b/lua/Comment/extra.lua
@@ -7,15 +7,15 @@ local extra = {}
 
 -- FIXME This prints `a` in i_CTRL-o
 ---Moves the cursor and enters INSERT mode
----@param row number Starting row
----@param col number Ending column
+---@param row integer Starting row
+---@param col integer Ending column
 local function move_n_insert(row, col)
     A.nvim_win_set_cursor(0, { row, col })
     A.nvim_feedkeys('a', 'ni', true)
 end
 
----@param count number Line index
----@param ctype number See |CommentType|
+---@param count integer Line index
+---@param ctype integer
 ---@param cfg CommentConfig
 local function ins_on_line(count, ctype, cfg)
     local row, col = unpack(A.nvim_win_get_cursor(0))
@@ -45,21 +45,21 @@ local function ins_on_line(count, ctype, cfg)
 end
 
 ---Add a comment below the current line and goes to INSERT mode
----@param ctype number See |CommentType|
+---@param ctype integer See |comment.utils.ctype|
 ---@param cfg CommentConfig
 function extra.insert_below(ctype, cfg)
     ins_on_line(0, ctype, cfg)
 end
 
 ---Add a comment above the current line and goes to INSERT mode
----@param ctype number See |CommentType|
+---@param ctype integer See |comment.utils.ctype|
 ---@param cfg CommentConfig
 function extra.insert_above(ctype, cfg)
     ins_on_line(-1, ctype, cfg)
 end
 
 ---Add a comment at the end of current line and goes to INSERT mode
----@param ctype number See |CommentType|
+---@param ctype integer See |comment.utils.ctype|
 ---@param cfg CommentConfig
 function extra.insert_eol(ctype, cfg)
     local srow, scol = unpack(A.nvim_win_get_cursor(0))

--- a/lua/Comment/extra.lua
+++ b/lua/Comment/extra.lua
@@ -32,7 +32,7 @@ local function ins_on_line(count, ctype, cfg)
     local lcs, rcs = U.parse_cstr(cfg, ctx)
     local line = A.nvim_get_current_line()
     local indent = U.indent_len(line)
-    local padding = U.get_padding(cfg.padding)
+    local padding = U.get_pad(cfg.padding)
 
     -- We need RHS of cstr, if we are doing block comments or if RHS exists
     -- because even in line comment RHS do exists for some filetypes like jsx_element, ocaml
@@ -74,7 +74,7 @@ function extra.insert_eol(ctype, cfg)
     local lcs, rcs = U.parse_cstr(cfg, ctx)
 
     local line = A.nvim_get_current_line()
-    local padding = U.get_padding(cfg.padding)
+    local padding = U.get_pad(cfg.padding)
 
     -- We need RHS of cstr, if we are doing block comments or if RHS exists
     -- because even in line comment RHS do exists for some filetypes like jsx_element, ocaml

--- a/lua/Comment/ft.lua
+++ b/lua/Comment/ft.lua
@@ -19,7 +19,8 @@ local M = {
 }
 
 ---Lang table that contains commentstring (linewise/blockwise) for mutliple filetypes
----@type table { filetype = { linewise, blockwise } }
+---Structure = { filetype = { linewise, blockwise } }
+---@type table<string,string[]>
 local L = {
     arduino = { M.cxx_l, M.cxx_b },
     bash = { M.hash },
@@ -115,7 +116,7 @@ end
 
 ---Get a commentstring from the filtype list
 ---@param lang CommentLang
----@param ctype number See |CommentType|
+---@param ctype integer See |comment.utils.ctype|
 ---@return string
 function ft.get(lang, ctype)
     local l = ft.lang(lang)
@@ -124,16 +125,16 @@ end
 
 ---Get the commentstring(s) from the filtype list
 ---@param lang CommentLang
----@return string
+---@return string[]
 function ft.lang(lang)
     return L[lang]
 end
 
 ---Get the tree in range by walking the whole tree recursively
----NOTE: This ignores `comment` parser as this is useless
+---NOTE: This ignores `comment` parser as this is not needed
 ---@param tree userdata Tree to be walked
----@param range number[] Range to check for
----@return userdata
+---@param range integer[] Range to check - {start_line, s_col, end_line, end_col}
+---@return userdata _ Returns a 'treesitter-languagetree'
 function ft.contains(tree, range)
     for lang, child in pairs(tree:children()) do
         if lang ~= 'comment' and child:contains(range) then
@@ -166,6 +167,7 @@ function ft.calculate(ctx)
     return ft.get(lang, ctx.ctype) or default
 end
 
+---@export ft
 return setmetatable(ft, {
     __newindex = function(this, k, v)
         this.set(k, v)

--- a/lua/Comment/ft.lua
+++ b/lua/Comment/ft.lua
@@ -115,7 +115,7 @@ end
 
 ---Get a commentstring from the filtype list
 ---@param lang CommentLang
----@param ctype CommentType
+---@param ctype number See |CommentType|
 ---@return string
 function ft.get(lang, ctype)
     local l = ft.lang(lang)

--- a/lua/Comment/opfunc.lua
+++ b/lua/Comment/opfunc.lua
@@ -145,13 +145,17 @@ function Op.linewise(param)
         cmode = param.cmode
     end
 
-    local uncomment = cmode == U.cmode.uncomment
-    for i, line in ipairs(param.lines) do
-        if not U.ignore(line, pattern) then
-            if uncomment then
+    if cmode == U.cmode.uncomment then
+        for i, line in ipairs(param.lines) do
+            if not U.ignore(line, pattern) then
                 param.lines[i] = U.uncomment_str(line, lcs_esc, rcs_esc, pp)
-            else
-                param.lines[i] = U.comment_str(line, param.lcs, param.rcs, padding, min_indent)
+            end
+        end
+    else
+        local comment = U.commenter(param.lcs, param.rcs, padding, min_indent)
+        for i, line in ipairs(param.lines) do
+            if not U.ignore(line, pattern) then
+                param.lines[i] = comment(line)
             end
         end
     end
@@ -221,7 +225,7 @@ function Op.blockwise_x(param)
 
     local padding, pp = U.get_padding(param.cfg.padding)
 
-    local yes, _, stripped = U.is_commented(U.escape(param.lcs), U.escape(param.rcs), pp)(mid)
+    local yes, _, stripped = U.is_commented(vim.pesc(param.lcs), vim.pesc(param.rcs), pp)(mid)
 
     local cmode
     if param.cmode == U.cmode.toggle then

--- a/lua/Comment/opfunc.lua
+++ b/lua/Comment/opfunc.lua
@@ -110,7 +110,7 @@ end
 function Op.linewise(param)
     local pattern = U.is_fn(param.cfg.ignore)
     local padding, pp = U.get_padding(param.cfg.padding)
-    local check = U.is_commented(param.lcs, param.rcs, pp)
+    local check = U.is_commented(param.lcs, param.rcs, param.cfg.padding)
 
     -- While commenting a region, there could be lines being both commented and non-commented
     -- So, if any line is uncommented then we should comment the whole block or vise-versa
@@ -182,8 +182,8 @@ function Op.blockwise(param, partial)
     -- If given mode is toggle then determine whether to comment or not
     local cmode = param.cmode
     if cmode == U.cmode.toggle then
-        local s_cmt = U.is_commented(param.lcs, '', pp)(sln, scol, -1)
-        local e_cmt = U.is_commented('', param.rcs, pp)(eln, 0, ecol)
+        local s_cmt = U.is_commented(param.lcs, '', param.cfg.padding)(sln, scol, -1)
+        local e_cmt = U.is_commented('', param.rcs, param.cfg.padding)(eln, 0, ecol)
         cmode = (s_cmt and e_cmt) and U.cmode.uncomment or U.cmode.comment
     end
 
@@ -211,7 +211,7 @@ function Op.blockwise_x(param)
 
     local cmode = param.cmode
     if cmode == U.cmode.toggle then
-        local is_cmt = U.is_commented(param.lcs, param.rcs, pp)(line, scol, ecol)
+        local is_cmt = U.is_commented(param.lcs, param.rcs, param.cfg.padding)(line, scol, ecol)
         cmode = is_cmt and U.cmode.uncomment or U.cmode.comment
     end
 

--- a/lua/Comment/opfunc.lua
+++ b/lua/Comment/opfunc.lua
@@ -59,7 +59,7 @@ function Op.opfunc(opmode, cfg, cmode, ctype, cmotion)
 
     -- sometimes there might be a case when there are no lines
     -- like, executing a text object returns nothing
-    if #lines == 0 then
+    if U.is_empty(lines) then
         return
     end
 
@@ -171,10 +171,9 @@ end
 ---@param partial? boolean Comment the partial region (visual mode)
 ---@return number
 function Op.blockwise(param, partial)
-    -- Block wise, only when there are more than 1 lines
     local sln, eln = param.lines[1], param.lines[#param.lines]
-    local padding, pp = U.get_padding(param.cfg.padding)
 
+    local padding, pp = U.get_padding(param.cfg.padding)
     local scol, ecol = nil, nil
     if partial then
         scol, ecol = param.range.scol, param.range.ecol
@@ -209,18 +208,19 @@ function Op.blockwise_x(param)
     local line = param.lines[1]
 
     local padding, pp = U.get_padding(param.cfg.padding)
+    local scol, ecol = param.range.scol, param.range.ecol
 
     local cmode = param.cmode
     if cmode == U.cmode.toggle then
-        local is_cmt = U.is_commented(param.lcs, param.rcs, pp)(line, param.range.scol, param.range.ecol)
+        local is_cmt = U.is_commented(param.lcs, param.rcs, pp)(line, scol, ecol)
         cmode = is_cmt and U.cmode.uncomment or U.cmode.comment
     end
 
     if cmode == U.cmode.uncomment then
-        local uncommented = U.uncommenter(param.lcs, param.rcs, pp, param.range.scol, param.range.ecol)(line)
+        local uncommented = U.uncommenter(param.lcs, param.rcs, pp, scol, ecol)(line)
         A.nvim_set_current_line(uncommented)
     else
-        local commented = U.commenter(param.lcs, param.rcs, param.range.scol, param.range.ecol, padding)(line)
+        local commented = U.commenter(param.lcs, param.rcs, scol, ecol, padding)(line)
         A.nvim_set_current_line(commented)
     end
 

--- a/lua/Comment/opfunc.lua
+++ b/lua/Comment/opfunc.lua
@@ -6,18 +6,24 @@ local A = vim.api
 
 local Op = {}
 
----@alias OpMode 'line'|'char'|'v'|'V' Vim operator-mode motions. Read `:h map-operator`
+---Vim operator-mode motions.
+---Read `:h :map-operator`
+---@alias OpMode
+---| 'line' # Vertical motion
+---| 'char' # Horizontal motion
+---| 'v' # Visual Block motion
+---| 'V' # Visual Line motion
 
 ---@class CommentCtx Comment context
----@field ctype number CommentType
----@field cmode number CommentMode
----@field cmotion number CommentMotion
+---@field ctype integer See |comment.utils.ctype|
+---@field cmode integer See |comment.utils.cmode|
+---@field cmotion integer See |comment.utils.cmotion|
 ---@field range CommentRange
 
 ---@class OpFnParams Operator-mode function parameters
 ---@field cfg CommentConfig
----@field cmode number See |comment.utils.cmode|
----@field lines table List of lines
+---@field cmode integer See |comment.utils.cmode|
+---@field lines string[] List of lines
 ---@field rcs string RHS of commentstring
 ---@field lcs string LHS of commentstring
 ---@field range CommentRange
@@ -26,28 +32,10 @@ local Op = {}
 ---This function contains the core logic for comment/uncomment
 ---@param opmode OpMode
 ---@param cfg CommentConfig
----@param cmode number CommentMode
----@param ctype number CommentType
----@param cmotion number CommentMotion
+---@param cmode integer See |comment.utils.cmode|
+---@param ctype integer See |comment.utils.ctype|
+---@param cmotion integer See |comment.utils.cmotion|
 function Op.opfunc(opmode, cfg, cmode, ctype, cmotion)
-    -- comment/uncomment logic
-    --
-    -- 1. type == line
-    --      * decide whether to comment or not, if all the lines are commented then uncomment otherwise comment
-    --      * also, store the minimum indent from all the lines (exclude empty line)
-    --      * if comment the line, use cstr LHS and also considering the min indent
-    --      * if uncomment the line, remove cstr LHS from lines
-    --      * update the lines
-    -- 2. type == block
-    --      * check if the first and last is commented or not with cstr LHS and RHS respectively.
-    --      * if both lines commented
-    --          - remove cstr LHS from the first line
-    --          - remove cstr RHS to end of the last line
-    --      * if both lines uncommented
-    --          - add cstr LHS after the leading whitespace and before the first char of the first line
-    --          - add cstr RHS to end of the last line
-    --      * update the lines
-
     cmotion = cmotion == U.cmotion._ and U.cmotion[opmode] or cmotion
 
     local range = U.get_region(opmode)
@@ -103,7 +91,7 @@ end
 
 ---Line commenting
 ---@param param OpFnParams
----@return number
+---@return integer _ Returns a calculated comment mode
 function Op.linewise(param)
     local pattern = U.is_fn(param.cfg.ignore)
     local padding = U.is_fn(param.cfg.padding)
@@ -161,10 +149,10 @@ function Op.linewise(param)
     return cmode
 end
 
----Full/Partial/Current-line Block commenting
+---Full/Partial/Current-Line Block commenting
 ---@param param OpFnParams
 ---@param partial? boolean Comment the partial region (visual mode)
----@return number
+---@return integer _ Returns a calculated comment mode
 function Op.blockwise(param, partial)
     local is_x = #param.lines == 1 -- current-line blockwise
     local lines = is_x and param.lines[1] or param.lines
@@ -198,11 +186,11 @@ function Op.blockwise(param, partial)
     return cmode
 end
 
----Toggle line comment with count i.e vim.v.count
----Example: `10gl` will comment 10 lines
----@param count number Number of lines
+---Line commenting with count i.e vim.v.count
+---Example: '10gl' will comment 10 lines
+---@param count integer Number of lines
 ---@param cfg CommentConfig
----@param ctype number CommentType
+---@param ctype integer See |comment.utils.ctype|
 function Op.count(count, cfg, ctype)
     local lines, range = U.get_count_lines(count)
 

--- a/lua/Comment/opfunc.lua
+++ b/lua/Comment/opfunc.lua
@@ -103,7 +103,7 @@ end
 function Op.linewise(param)
     local pattern = U.is_fn(param.cfg.ignore)
     local padding, pp = U.get_padding(param.cfg.padding)
-    local check = U.is_commented2(param.lcs, param.rcs, pp)
+    local check = U.is_commented(param.lcs, param.rcs, pp)
 
     -- While commenting a region, there could be lines being both commented and non-commented
     -- So, if any line is uncommented then we should comment the whole block or vise-versa
@@ -173,8 +173,8 @@ function Op.blockwise(param, partial)
     -- If given mode is toggle then determine whether to comment or not
     local cmode = param.cmode
     if cmode == U.cmode.toggle then
-        local s_cmt = U.is_commented2(param.lcs, '', pp)(sln, scol, -1)
-        local e_cmt = U.is_commented2('', param.rcs, pp)(eln, 1, ecol)
+        local s_cmt = U.is_commented(param.lcs, '', pp)(sln, scol, -1)
+        local e_cmt = U.is_commented('', param.rcs, pp)(eln, 1, ecol)
         cmode = (s_cmt and e_cmt) and U.cmode.uncomment or U.cmode.comment
     end
 
@@ -218,7 +218,7 @@ function Op.blockwise_x(param)
 
     local cmode = param.cmode
     if cmode == U.cmode.toggle then
-        local is_cmt = U.is_commented2(param.lcs, param.rcs, pp)(line, param.range.scol, param.range.ecol + 1)
+        local is_cmt = U.is_commented(param.lcs, param.rcs, pp)(line, param.range.scol, param.range.ecol + 1)
         cmode = is_cmt and U.cmode.uncomment or U.cmode.comment
     end
 

--- a/lua/Comment/opfunc.lua
+++ b/lua/Comment/opfunc.lua
@@ -110,7 +110,7 @@ end
 function Op.linewise(param)
     local pattern = U.is_fn(param.cfg.ignore)
     local padding = U.is_fn(param.cfg.padding)
-    local check = U.is_commented(param.lcs, param.rcs, padding)
+    local check = U.is_commented(param.lcs, param.rcs, nil, nil, padding)
 
     -- While commenting a region, there could be lines being both commented and non-commented
     -- So, if any line is uncommented then we should comment the whole block or vise-versa
@@ -182,9 +182,8 @@ function Op.blockwise(param, partial)
     -- If given mode is toggle then determine whether to comment or not
     local cmode = param.cmode
     if cmode == U.cmode.toggle then
-        local s_cmt = U.is_commented(param.lcs, '', padding)(sln, scol, -1)
-        local e_cmt = U.is_commented('', param.rcs, padding)(eln, 0, ecol)
-        cmode = (s_cmt and e_cmt) and U.cmode.uncomment or U.cmode.comment
+        local is_cmt = U.is_commented(param.lcs, param.rcs, scol, ecol, padding)({ sln, eln })
+        cmode = is_cmt and U.cmode.uncomment or U.cmode.comment
     end
 
     local l1, l2
@@ -211,7 +210,7 @@ function Op.blockwise_x(param)
 
     local cmode = param.cmode
     if cmode == U.cmode.toggle then
-        local is_cmt = U.is_commented(param.lcs, param.rcs, padding)(line, scol, ecol)
+        local is_cmt = U.is_commented(param.lcs, param.rcs, scol, ecol, padding)(line)
         cmode = is_cmt and U.cmode.uncomment or U.cmode.comment
     end
 

--- a/lua/Comment/opfunc.lua
+++ b/lua/Comment/opfunc.lua
@@ -110,7 +110,7 @@ end
 function Op.linewise(param)
     local pattern = U.is_fn(param.cfg.ignore)
     local padding = U.is_fn(param.cfg.padding)
-    local check = U.is_commented(param.lcs, param.rcs, nil, nil, padding)
+    local check = U.is_commented(param.lcs, param.rcs, padding)
 
     -- While commenting a region, there could be lines being both commented and non-commented
     -- So, if any line is uncommented then we should comment the whole block or vise-versa
@@ -144,14 +144,14 @@ function Op.linewise(param)
     end
 
     if cmode == U.cmode.uncomment then
-        local uncomment = U.uncommenter(param.lcs, param.rcs, nil, nil, padding)
+        local uncomment = U.uncommenter(param.lcs, param.rcs, padding)
         for i, line in ipairs(param.lines) do
             if not U.ignore(line, pattern) then
                 param.lines[i] = uncomment(line)
             end
         end
     else
-        local comment = U.commenter(param.lcs, param.rcs, min_indent, nil, padding)
+        local comment = U.commenter(param.lcs, param.rcs, padding, min_indent)
         for i, line in ipairs(param.lines) do
             if not U.ignore(line, pattern) then
                 param.lines[i] = comment(line)
@@ -182,15 +182,15 @@ function Op.blockwise(param, partial)
     -- If given mode is toggle then determine whether to comment or not
     local cmode = param.cmode
     if cmode == U.cmode.toggle then
-        local is_cmt = U.is_commented(param.lcs, param.rcs, scol, ecol, padding)({ sln, eln })
+        local is_cmt = U.is_commented(param.lcs, param.rcs, padding, scol, ecol)({ sln, eln })
         cmode = is_cmt and U.cmode.uncomment or U.cmode.comment
     end
 
     local l1, l2
     if cmode == U.cmode.uncomment then
-        l1, l2 = U.uncommenter(param.lcs, param.rcs, scol, ecol, padding)({ sln, eln })
+        l1, l2 = U.uncommenter(param.lcs, param.rcs, padding, scol, ecol)({ sln, eln })
     else
-        l1, l2 = U.commenter(param.lcs, param.rcs, scol, ecol, padding)({ sln, eln })
+        l1, l2 = U.commenter(param.lcs, param.rcs, padding, scol, ecol)({ sln, eln })
     end
 
     A.nvim_buf_set_lines(0, param.range.srow - 1, param.range.srow, false, { l1 })
@@ -210,15 +210,15 @@ function Op.blockwise_x(param)
 
     local cmode = param.cmode
     if cmode == U.cmode.toggle then
-        local is_cmt = U.is_commented(param.lcs, param.rcs, scol, ecol, padding)(line)
+        local is_cmt = U.is_commented(param.lcs, param.rcs, padding, scol, ecol)(line)
         cmode = is_cmt and U.cmode.uncomment or U.cmode.comment
     end
 
     if cmode == U.cmode.uncomment then
-        local uncommented = U.uncommenter(param.lcs, param.rcs, scol, ecol, padding)(line)
+        local uncommented = U.uncommenter(param.lcs, param.rcs, padding, scol, ecol)(line)
         A.nvim_set_current_line(uncommented)
     else
-        local commented = U.commenter(param.lcs, param.rcs, scol, ecol, padding)(line)
+        local commented = U.commenter(param.lcs, param.rcs, padding, scol, ecol)(line)
         A.nvim_set_current_line(commented)
     end
 

--- a/lua/Comment/opfunc.lua
+++ b/lua/Comment/opfunc.lua
@@ -55,6 +55,14 @@ function Op.opfunc(opmode, cfg, cmode, ctype, cmotion)
     local partial_block = cmotion == U.cmotion.char or cmotion == U.cmotion.v
     local block_x = partial_block and same_line
 
+    local lines = U.get_lines(range)
+
+    -- sometimes there might be a case when there are no lines
+    -- like, executing a text object returns nothing
+    if #lines == 0 then
+        return
+    end
+
     ---@type CommentCtx
     local ctx = {
         cmode = cmode,
@@ -64,7 +72,6 @@ function Op.opfunc(opmode, cfg, cmode, ctype, cmotion)
     }
 
     local lcs, rcs = U.parse_cstr(cfg, ctx)
-    local lines = U.get_lines(range)
 
     ---@type OpFnParams
     local params = {

--- a/lua/Comment/opfunc.lua
+++ b/lua/Comment/opfunc.lua
@@ -116,9 +116,9 @@ function Op.linewise(param)
     -- So, if any line is uncommented then we should comment the whole block or vise-versa
     local cmode = U.cmode.uncomment
 
-    -- When commenting multiple line, it is to be expected that indentation should be preserved
-    -- So, When looping over multiple lines we need to store the indentation of the mininum length (except empty line)
-    -- Which will be used to semantically comment rest of the lines
+    ---When commenting multiple line, it is to be expected that indentation should be preserved
+    ---So, When looping over multiple lines we need to store the indentation of the mininum length (except empty line)
+    ---Which will be used to semantically comment rest of the lines
     ---@type integer
     local min_indent = nil
 
@@ -151,12 +151,7 @@ function Op.linewise(param)
             end
         end
     else
-        local comment = U.commenter({
-            left = param.lcs,
-            right = param.rcs,
-            scol = min_indent,
-            padding = padding,
-        })
+        local comment = U.commenter(param.lcs, param.rcs, min_indent, nil, padding)
         for i, line in ipairs(param.lines) do
             if not U.ignore(line, pattern) then
                 param.lines[i] = comment(line)
@@ -213,13 +208,7 @@ function Op.blockwise(param, partial)
             l2 = l2 .. eln:sub(param.range.ecol + 2)
         end
     else
-        l1, l2 = U.commenter({
-            left = param.lcs,
-            right = param.rcs,
-            scol = scol,
-            ecol = ecol,
-            padding = padding,
-        })({ sln, eln })
+        l1, l2 = U.commenter(param.lcs, param.rcs, scol, ecol, padding)({ sln, eln })
     end
 
     A.nvim_buf_set_lines(0, param.range.srow - 1, param.range.srow, false, { l1 })
@@ -250,13 +239,7 @@ function Op.blockwise_x(param)
 
         A.nvim_set_current_line(first .. mid .. last)
     else
-        local commented = U.commenter({
-            left = param.lcs,
-            right = param.rcs,
-            scol = param.range.scol,
-            ecol = param.range.ecol,
-            padding = padding,
-        })(line)
+        local commented = U.commenter(param.lcs, param.rcs, param.range.scol, param.range.ecol, padding)(line)
         A.nvim_set_current_line(commented)
     end
 

--- a/lua/Comment/opfunc.lua
+++ b/lua/Comment/opfunc.lua
@@ -127,7 +127,7 @@ function Op.linewise(param)
                 -- If local `cmode` == comment or the given cmode ~= uncomment, then only calculate min_indent
                 -- As calculating min_indent only makes sense when we actually want to comment the lines
                 if not U.is_empty(line) and (cmode == U.cmode.comment or param.cmode == U.cmode.comment) then
-                    local _, len = U.grab_indent(line)
+                    local len = U.indent_len(line)
                     if not min_indent or min_indent > len then
                         min_indent = len
                     end

--- a/lua/Comment/opfunc.lua
+++ b/lua/Comment/opfunc.lua
@@ -120,7 +120,7 @@ function Op.linewise(param)
     ---So, When looping over multiple lines we need to store the indentation of the mininum length (except empty line)
     ---Which will be used to semantically comment rest of the lines
     ---@type integer
-    local min_indent = nil
+    local min_indent = -1
 
     -- If the given cmode is uncomment then we actually don't want to compute the cmode or min_indent
     if param.cmode ~= U.cmode.uncomment then
@@ -135,7 +135,7 @@ function Op.linewise(param)
                 -- As calculating min_indent only makes sense when we actually want to comment the lines
                 if not U.is_empty(line) and (cmode == U.cmode.comment or param.cmode == U.cmode.comment) then
                     local len = U.indent_len(line)
-                    if not min_indent or min_indent > len then
+                    if min_indent == -1 or min_indent > len then
                         min_indent = len
                     end
                 end

--- a/lua/Comment/opfunc.lua
+++ b/lua/Comment/opfunc.lua
@@ -144,7 +144,7 @@ function Op.linewise(param)
     end
 
     if cmode == U.cmode.uncomment then
-        local uncomment = U.uncommenter(param.lcs, param.rcs, pp)
+        local uncomment = U.uncommenter(param.lcs, param.rcs, nil, nil, pp)
         for i, line in ipairs(param.lines) do
             if not U.ignore(line, pattern) then
                 param.lines[i] = uncomment(line)
@@ -189,8 +189,7 @@ function Op.blockwise(param, partial)
 
     local l1, l2
     if cmode == U.cmode.uncomment then
-        l1 = U.uncommenter(param.lcs, '', pp, scol, nil)(sln)
-        l2 = U.uncommenter('', param.rcs, pp, nil, ecol)(eln)
+        l1, l2 = U.uncommenter(param.lcs, param.rcs, scol, ecol, pp)({ sln, eln })
     else
         l1, l2 = U.commenter(param.lcs, param.rcs, scol, ecol, padding)({ sln, eln })
     end
@@ -217,7 +216,7 @@ function Op.blockwise_x(param)
     end
 
     if cmode == U.cmode.uncomment then
-        local uncommented = U.uncommenter(param.lcs, param.rcs, pp, scol, ecol)(line)
+        local uncommented = U.uncommenter(param.lcs, param.rcs, scol, ecol, pp)(line)
         A.nvim_set_current_line(uncommented)
     else
         local commented = U.commenter(param.lcs, param.rcs, scol, ecol, padding)(line)

--- a/lua/Comment/utils.lua
+++ b/lua/Comment/utils.lua
@@ -216,18 +216,20 @@ function U.commenter(left, right, padding, scol, ecol)
         -- for blockwise --
         -------------------
         if type(line) == 'table' then
-            local first, last = unpack(line)
+            local first, last = line[1], line[#line]
             -- If both columns are given then we can assume it's a partial block
             if scol and ecol then
                 local sfirst = string.sub(first, 0, scol)
                 local slast = string.sub(first, scol + 1, -1)
                 local efirst = string.sub(last, 0, ecol + 1)
                 local elast = string.sub(last, ecol + 2, -1)
-                return (sfirst .. ll .. slast), (efirst .. rr .. elast)
+                line[1] = sfirst .. ll .. slast
+                line[#line] = efirst .. rr .. elast
+            else
+                line[1] = U.is_empty(first) and left or string.gsub(first, '^(%s*)', '%1' .. ll)
+                line[#line] = U.is_empty(last) and right or (last .. rr)
             end
-            first = U.is_empty(first) and left or string.gsub(first, '^(%s*)', '%1' .. ll)
-            last = U.is_empty(last) and right or (last .. rr)
-            return first, last
+            return line
         end
 
         --------------------------------
@@ -260,16 +262,20 @@ function U.uncommenter(left, right, padding, scol, ecol)
         -- for blockwise --
         -------------------
         if type(line) == 'table' then
-            local first, last = unpack(line)
+            local first, last = line[1], line[#line]
             -- If both columns are given then we can assume it's a partial block
             if scol and ecol then
                 local sfirst = string.sub(first, 0, scol)
                 local slast = string.sub(first, scol + left_len + 1, -1)
                 local efirst = string.sub(last, 0, ecol - right_len + 1)
                 local elast = string.sub(last, ecol + 2, -1)
-                return (sfirst .. slast), (efirst .. elast)
+                line[1] = sfirst .. slast
+                line[#line] = efirst .. elast
+            else
+                line[1] = string.gsub(first, '^(%s*)' .. ll, '%1')
+                line[#line] = string.gsub(last, rr .. '$', '')
             end
-            return string.gsub(first, '^(%s*)' .. ll, '%1'), string.gsub(last, rr .. '$', '')
+            return line
         end
 
         ------------------
@@ -298,7 +304,7 @@ end
 ---@param padding boolean Is padding enabled?
 ---@param scol? integer Starting column
 ---@param ecol? integer Ending column
----@return fun(line:string):boolean
+---@return fun(line:string|string[]):boolean
 function U.is_commented(left, right, padding, scol, ecol)
     local pp = U.get_padpat(padding)
     local ll = U.is_empty(left) and left or '^%s*' .. vim.pesc(left) .. pp
@@ -311,7 +317,7 @@ function U.is_commented(left, right, padding, scol, ecol)
         -- for blockwise --
         -------------------
         if type(line) == 'table' then
-            local first, last = unpack(line)
+            local first, last = line[1], line[#line]
             if is_full then
                 return string.find(first, ll) and string.find(last, rr)
             end

--- a/lua/Comment/utils.lua
+++ b/lua/Comment/utils.lua
@@ -62,14 +62,12 @@ function U.is_empty(ln)
     return #ln == 0
 end
 
----Takes out the leading indent from lines
+---Get the length of the indentation
 ---@param str string
----@return string string Indent chars
----@return integer integer Length of the indent chars
-function U.grab_indent(str)
-    -- local _, len = string.find(str, '^%s*')
-    local _, len, indent = string.find(str, '^(%s*)')
-    return indent, len
+---@return integer integer Length of indent chars
+function U.indent_len(str)
+    local _, len = string.find(str, '^%s*')
+    return len
 end
 
 ---Helper to get padding character and regex pattern
@@ -82,15 +80,6 @@ function U.get_padding(flag)
         return '', ''
     end
     return ' ', '%s?'
-end
-
--- FIXME This prints `a` in i_CTRL-o
----Moves the cursor and enters INSERT mode
----@param row number Starting row
----@param col number Ending column
-function U.move_n_insert(row, col)
-    A.nvim_win_set_cursor(0, { row, col })
-    A.nvim_feedkeys('a', 'ni', true)
 end
 
 ---Call a function if exists
@@ -239,7 +228,7 @@ function U.uncomment_str(ln, lcs_esc, rcs_esc, pp)
 end
 
 ---Check if the given string is commented or not
----@param left string Escaped Left side of the commentstring
+---@param left string Left side of the commentstring
 ---@param right string Right side of the commentstring
 ---@param pp string Padding pattern. See |U.get_padding|
 ---@return fun(line:string,scol?:integer,ecol?:integer):boolean

--- a/lua/Comment/utils.lua
+++ b/lua/Comment/utils.lua
@@ -199,10 +199,10 @@ function U.commenter(left, right, scol, ecol, padding)
         ------------------
         -- for linewise --
         ------------------
-        if U.is_empty(line) then
-            return empty
-        end
         if is_lw then
+            if U.is_empty(line) then
+                return empty
+            end
             -- line == 0 -> start from 0 col
             if scol == 0 then
                 return (ll .. line .. rr)

--- a/lua/Comment/utils.lua
+++ b/lua/Comment/utils.lua
@@ -290,9 +290,10 @@ end
 ---Check if the given string is commented or not
 ---@param left string Left side of the commentstring
 ---@param right string Right side of the commentstring
----@param pp string Padding pattern. See |U.get_padding|
+---@param padding boolean Is padding enabled?
 ---@return fun(line:string,scol?:integer,ecol?:integer):boolean
-function U.is_commented(left, right, pp)
+function U.is_commented(left, right, padding)
+    local pp = padding and '%s?' or ''
     local ll = U.is_empty(left) and left or '^%s*' .. vim.pesc(left) .. pp
     local rr = U.is_empty(right) and right or pp .. vim.pesc(right) .. '$'
     local pattern = ll .. '.-' .. rr

--- a/lua/Comment/utils.lua
+++ b/lua/Comment/utils.lua
@@ -243,7 +243,7 @@ end
 ---@param right string Right side of the commentstring
 ---@param pp string Padding pattern. See |U.get_padding|
 ---@return fun(line:string,scol?:integer,ecol?:integer):boolean
-function U.is_commented2(left, right, pp)
+function U.is_commented(left, right, pp)
     local ll = U.is_empty(left) and left or table.concat({ '^%s*', vim.pesc(left), pp })
     local rr = U.is_empty(right) and right or table.concat({ pp, vim.pesc(right), '$' })
     local pattern = table.concat({ ll, '.-', rr })

--- a/lua/Comment/utils.lua
+++ b/lua/Comment/utils.lua
@@ -184,11 +184,11 @@ end
 ---else it will do linewise
 ---@param left string Left side of the commentstring
 ---@param right string Right side of the commentstring
+---@param padding boolean Is padding enabled?
 ---@param scol? integer Starting column
 ---@param ecol? integer Ending column
----@param padding boolean Is padding enabled?
 ---@return fun(line:string|string[]):string
-function U.commenter(left, right, scol, ecol, padding)
+function U.commenter(left, right, padding, scol, ecol)
     local pad = U.get_pad(padding)
     local ll = U.is_empty(left) and left or (left .. pad)
     local rr = U.is_empty(right) and right or (pad .. right)
@@ -243,11 +243,11 @@ end
 ---Returns a closure which is used to uncomment a line
 ---@param left string Left side of the commentstring
 ---@param right string Right side of the commentstring
+---@param padding boolean Is padding enabled?
 ---@param scol? integer Starting column
 ---@param ecol? integer Ending column
----@param padding boolean Is padding enabled?
 ---@return fun(line:string|string[]):string
-function U.uncommenter(left, right, scol, ecol, padding)
+function U.uncommenter(left, right, padding, scol, ecol)
     local pp, plen = U.get_padpat(padding), padding and 1 or 0
     local left_len, right_len = #left + plen, #right + plen
     local ll = U.is_empty(left) and left or vim.pesc(left) .. pp
@@ -295,11 +295,11 @@ end
 ---Check if the given string is commented or not
 ---@param left string Left side of the commentstring
 ---@param right string Right side of the commentstring
+---@param padding boolean Is padding enabled?
 ---@param scol? integer Starting column
 ---@param ecol? integer Ending column
----@param padding boolean Is padding enabled?
 ---@return fun(line:string):boolean
-function U.is_commented(left, right, scol, ecol, padding)
+function U.is_commented(left, right, padding, scol, ecol)
     local pp = U.get_padpat(padding)
     local ll = U.is_empty(left) and left or '^%s*' .. vim.pesc(left) .. pp
     local rr = U.is_empty(right) and right or pp .. vim.pesc(right) .. '$'

--- a/lua/Comment/utils.lua
+++ b/lua/Comment/utils.lua
@@ -110,7 +110,7 @@ function U.get_region(opmode)
         return { srow = row, scol = 0, erow = row, ecol = 0 }
     end
 
-    local marks = string.match(opmode, '[vV]') ~= nil and { '<', '>' } or { '[', ']' }
+    local marks = string.match(opmode, '[vV]') and { '<', '>' } or { '[', ']' }
     local sln, eln = A.nvim_buf_get_mark(0, marks[1]), A.nvim_buf_get_mark(0, marks[2])
 
     return { srow = sln[1], scol = sln[2], erow = eln[1], ecol = eln[2] }
@@ -174,6 +174,7 @@ function U.parse_cstr(cfg, ctx)
     return U.unwrap_cstr(cstr)
 end
 
+--FIXME: this is a mess
 ---Returns a closure which is used to comment a line
 ---@param left string Left side of the commentstring
 ---@param right string Right side of the commentstring

--- a/lua/Comment/utils.lua
+++ b/lua/Comment/utils.lua
@@ -56,10 +56,10 @@ U.cmotion = {
 }
 
 ---Check whether the line is empty
----@param ln string
+---@param iter string|string[]
 ---@return boolean
-function U.is_empty(ln)
-    return #ln == 0
+function U.is_empty(iter)
+    return #iter == 0
 end
 
 ---Get the length of the indentation
@@ -219,8 +219,9 @@ function U.commenter(left, right, scol, ecol, padding)
                 local elast = string.sub(last, ecol + 2, -1)
                 return (sfirst .. ll .. slast), (efirst .. rr .. elast)
             end
-            -- FIXME: if line is empty then don't add leading or trailing padding
-            return string.gsub(first, '^(%s*)', '%1' .. ll), (last .. rr)
+            first = U.is_empty(first) and left or string.gsub(first, '^(%s*)', '%1' .. ll)
+            last = U.is_empty(last) and right or (last .. rr)
+            return first, last
         end
 
         --------------------------------
@@ -259,6 +260,7 @@ function U.uncommenter(left, right, pp, scol, ecol)
         pattern = '^(%s*)' .. ll .. '(.-)' .. rr .. '$'
     end
 
+    -- TODO: take string[] for blockwise
     return function(line)
         local a, b, c = string.match(line, pattern)
 
@@ -278,6 +280,7 @@ function U.is_commented(left, right, pp)
     local rr = U.is_empty(right) and right or pp .. vim.pesc(right) .. '$'
     local pattern = ll .. '.-' .. rr
 
+    -- TODO: take string[] for blockwise
     return function(line, scol, ecol)
         local ln = (scol == nil or ecol == nil) and line or string.sub(line, scol + 1, ecol == -1 and ecol or ecol + 1)
         return string.find(ln, pattern)

--- a/lua/Comment/utils.lua
+++ b/lua/Comment/utils.lua
@@ -185,6 +185,28 @@ function U.parse_cstr(cfg, ctx)
     return U.unwrap_cstr(cstr)
 end
 
+---Returns a closure which is used to comment a line
+---@param left string Left side of the commentstring
+---@param right string Right side of the commentstring
+---@param padding string Padding between comment chars and line
+---@param indent integer Left indentation to use with multiple lines
+---@return fun(line:string):string
+function U.commenter(left, right, padding, indent)
+    local ll = U.is_empty(left) and left or table.concat({ left, padding })
+    local rr = U.is_empty(right) and right or table.concat({ padding, right })
+    local repl = string.format('%%1%s%%2%s', ll, rr)
+    local pattern = indent > 0 and string.format('^(%s)(.*)', string.rep('%s', indent)) or '^(%s-)(.*)'
+
+    local empty = table.concat({ string.rep(' ', indent), left, right })
+
+    return function(line)
+        if U.is_empty(line) then
+            return empty
+        end
+        return string.gsub(line, pattern, repl, 1)
+    end
+end
+
 ---Converts the given string into a commented string
 ---@param ln string String that needs to be commented
 ---@param lcs string Left side of the commentstring


### PR DESCRIPTION
### Added
- `utils.commenter()`
- `utils.uncommenter()`

### Changed
- `utils.{unwrap_cstr,parse_cstr}()` now returns `string, string` instead of `string|bool, string|bool`
- Merged `Op.blockwise_x()` with `Op.blockwise()`
- Removed `utils.get_padding()`, `utils.move_n_insert()` and `utils.grab_indent()`
- Removed `utils.comment_str()` (Use `utils.commenter()`)
- Removed `utils.uncomment_str()` (Use `utils.uncommenter()`)
- Changed `utils.is_commented()` function signature.

---

This will break your setup if you are depending on the internal functions. So feel free ask anything regarding the above changes.

Resolve #177 