### PR TITLE
Add `replace_keycodes=false` to expr mappings

### DIFF
--- a/doc/plugs.md
+++ b/doc/plugs.md
@@ -18,7 +18,7 @@ Following are the `<Plug>` mappings which you can use to quickly setup your cust
 Following snippets is same as the default mappings set by the plugin.
 
 ```lua
-local opt = { expr = true, remap = true }
+local opt = { expr = true, remap = true, replace_keycodes = false }
 
 -- Toggle using count
 vim.keymap.set('n', 'gcc', "v:count == 0 ? '<Plug>(comment_toggle_current_linewise)' : '<Plug>(comment_toggle_linewise_count)'", opt)

--- a/lua/Comment/api.lua
+++ b/lua/Comment/api.lua
@@ -248,13 +248,13 @@ function api.setup(config)
                 'n',
                 cfg.toggler.line,
                 "v:count == 0 ? '<Plug>(comment_toggle_current_linewise)' : '<Plug>(comment_toggle_linewise_count)'",
-                { expr = true, remap = true }
+                { expr = true, remap = true, replace_keycodes = false }
             )
             K(
                 'n',
                 cfg.toggler.block,
                 "v:count == 0 ? '<Plug>(comment_toggle_current_blockwise)' : '<Plug>(comment_toggle_blockwise_count)'",
-                { expr = true, remap = true }
+                { expr = true, remap = true, replace_keycodes = false }
             )
 
             K('n', cfg.opleader.line, '<Plug>(comment_toggle_linewise)')


### PR DESCRIPTION
https://github.com/neovim/neovim/pull/19598 changed `vim.keymap.set` to replace keycodes by default for all mappings if `expr == true` instead of only luaref expr mappings.

The toggle expr mappings are not luarefs but shouldn't have the keycodes replaced since they use `<Plug>`.