### PR TITLE
fix: remove `lockmarks` from `gc{o,O}`

### DIFF
--- a/lua/Comment/api.lua
+++ b/lua/Comment/api.lua
@@ -478,7 +478,7 @@ api.locked = setmetatable({}, {
         ---@param motion OpMotion
         return function(motion)
             return A.nvim_command(
-                ('lockmarks lua require("Comment.api").%s(%s)'):format(cb, motion and ('%q'):format(motion))
+                ('lua require("Comment.api").%s(%s)'):format(cb, motion and ('%q'):format(motion))
             )
         end
     end,

--- a/lua/Comment/api.lua
+++ b/lua/Comment/api.lua
@@ -555,8 +555,8 @@ function api.setup(config)
 
         -- Extra Mappings
         if cfg.mappings.extra then
-            K('n', cfg.extra.below, api.locked('insert.linewise.below'), { desc = 'Comment insert below' })
-            K('n', cfg.extra.above, api.locked('insert.linewise.above'), { desc = 'Comment insert above' })
+            K('n', cfg.extra.below, api.insert.linewise.below, { desc = 'Comment insert below' })
+            K('n', cfg.extra.above, api.insert.linewise.above, { desc = 'Comment insert above' })
             K('n', cfg.extra.eol, api.locked('insert.linewise.eol'), { desc = 'Comment insert end of line' })
         end
 

--- a/lua/Comment/api.lua
+++ b/lua/Comment/api.lua
@@ -478,7 +478,7 @@ api.locked = setmetatable({}, {
         ---@param motion OpMotion
         return function(motion)
             return A.nvim_command(
-                ('lua require("Comment.api").%s(%s)'):format(cb, motion and ('%q'):format(motion))
+                ('lockmarks lua require("Comment.api").%s(%s)'):format(cb, motion and ('%q'):format(motion))
             )
         end
     end,


### PR DESCRIPTION
Resolves #219