### PR TITLE
Added support for sending commented block to configured register

### DIFF
--- a/lua/Comment/config.lua
+++ b/lua/Comment/config.lua
@@ -29,6 +29,10 @@
 ---        },
 ---        pre_hook = nil,
 ---        post_hook = nil,
+---        register = {
+---            copy = true,
+---            register = "'",
+---        }
 ---    }
 ---<
 ---@brief ]]
@@ -49,6 +53,7 @@
 ---NOTE: If given 'false', then the
 ---plugin won't create any mappings
 ---@field mappings Mappings|false
+---@field register Register
 ---@field toggler Toggler See |comment.config.Toggler|
 ---@field opleader Opleader See |comment.config.Opleader|
 ---@field extra ExtraMapping See |comment.config.ExtraMapping|
@@ -72,6 +77,14 @@
 ---(default: 'true')
 ---@field extra boolean
 
+---Send commented lines to register
+---@class Register
+---Toggles automagic paste to register when using comment motions
+---@field copy boolean
+---(default: 'true')
+---Choose register to send result to
+---@field register string
+---(default: '"')
 ---LHS of toggle mappings in NORMAL
 ---@class Toggler
 ---@field line string Linewise comment (default: 'gcc')
@@ -95,6 +108,10 @@
 local Config = {
     state = {},
     config = {
+        register = {
+            copy = true,
+            register = '"',
+        },
         padding = true,
         sticky = true,
         mappings = {

--- a/lua/Comment/init.lua
+++ b/lua/Comment/init.lua
@@ -84,6 +84,9 @@ local C = {}
 ---        line = '<leader>c',
 ---        block = '<leader>b',
 ---    },
+---    register = {
+---     register = 'a',
+---    },
 ---})
 ---@usage ]]
 function C.setup(config)

--- a/lua/Comment/opfunc.lua
+++ b/lua/Comment/opfunc.lua
@@ -42,6 +42,27 @@ function Op.opfunc(motion, cfg, cmode, ctype)
         return
     end
 
+    if cfg.register.copy then
+        local register = cfg.register.register or '"'
+        vim.notify('Copying to ' .. register)
+        local count = 0
+        -- save default register
+        local oldcontent = vim.fn.getreg('"')
+        for _, line in ipairs(lines) do
+            if count == 0 then
+                -- clear register
+                U.copy_to_register(register, line)
+                count = count + 1
+            else
+                U.copy_to_register(register, line .. '\n', 'a')
+            end
+        end
+        if register ~= '"' then
+            -- restore default register
+            U.copy_to_register('"', oldcontent)
+        end
+    end
+
     ---@type CommentCtx
     local ctx = {
         cmode = cmode,
@@ -88,7 +109,6 @@ end
 ---@param ctype integer See |comment.utils.ctype|
 function Op.count(count, cfg, cmode, ctype)
     local lines, range = U.get_count_lines(count)
-
     ---@type CommentCtx
     local ctx = {
         cmode = cmode,

--- a/lua/Comment/utils.lua
+++ b/lua/Comment/utils.lua
@@ -359,4 +359,9 @@ function U.is_commented(left, right, padding, scol, ecol)
     end
 end
 
+function U.copy_to_register(register, lines, opts)
+    vim.notify('adding ' .. lines .. ' to register ' .. register)
+    vim.fn.setreg(register, lines, opts)
+end
+
 return U


### PR DESCRIPTION
Sorry I can't figure out for the life of me how to remove all my test commits and previous commits. I'm new to this and made the mistake of working out of my forks master branch and now ¯\_(ツ)_/¯. 

I thought this would be a useful feature as I find myself often copying a block before I comment it out. This results in extra keypresses to target the same block (yip, gcip).

I was gonna just add this to a prehook but I figured other people might find it useful too. It's definitely WIP and should be tweaked (for example to allow configuration for copying after comment instead of copying before, or adding the functionality to a prefix keybind) and I can continue working on it myself, but I figured I'd post it here to check if it's something you think the plugin could benefit from and if I should keep working on it or not.