### PR TITLE
Prevent blockwise comments for languages which don't support them

### DIFF
--- a/lua/Comment/opfunc.lua
+++ b/lua/Comment/opfunc.lua
@@ -193,6 +193,11 @@ end
 ---@param partial? boolean Comment the partial region (visual mode)
 ---@return integer _ Returns a calculated comment mode
 function Op.blockwise(param, partial)
+    if U.is_empty(param.rcs) then
+        print(string.format('Error: %s does not support block comments', vim.bo.filetype))
+        return -1
+    end
+
     local is_x = #param.lines == 1 -- current-line blockwise
     local lines = is_x and param.lines[1] or param.lines
 

--- a/lua/Comment/opfunc.lua
+++ b/lua/Comment/opfunc.lua
@@ -194,7 +194,7 @@ end
 ---@return integer _ Returns a calculated comment mode
 function Op.blockwise(param, partial)
     if U.is_empty(param.rcs) then
-        print(string.format('Error: %s does not support block comments', vim.bo.filetype))
+        U.warn(string.format('Error: %s does not support block comments', vim.bo.filetype))
         return -1
     end
 

--- a/lua/Comment/utils.lua
+++ b/lua/Comment/utils.lua
@@ -28,6 +28,7 @@ local U = {}
 ---An object containing comment modes
 ---@type CommentMode
 U.cmode = {
+    error = -1,
     toggle = 0,
     comment = 1,
     uncomment = 2,

--- a/lua/Comment/utils.lua
+++ b/lua/Comment/utils.lua
@@ -74,9 +74,9 @@ end
 
 ---@private
 ---Display a warning message
----@param msg string
-function U.warn(msg)
-    vim.notify(msg, vim.log.levels.WARN)
+---@param message string
+function U.warn(message)
+    vim.notify(message, vim.log.levels.WARN, { title = "Comment.nvim" })
 end
 
 ---@private

--- a/lua/Comment/utils.lua
+++ b/lua/Comment/utils.lua
@@ -73,6 +73,13 @@ function U.is_empty(iter)
 end
 
 ---@private
+---Display a warning message
+---@param msg string
+function U.warn(msg)
+    vim.notify(msg, vim.log.levels.WARN)
+end
+
+---@private
 ---Helper to get padding character
 ---@param flag boolean
 ---@return string string


### PR DESCRIPTION
This pull request resolves #275 and supplants #276.

It prevents all blockwise comments, with an error message, where appropriate except for `gbc` which is treated as a linewise comment since `motion == nil` and is equivalent to `gcc` for languages without support for block comments. Should I also prevent `gbc`?

I've displayed the error message with Lua's `print` function. I considered using `vim.api.nvim_err_writeln` to display the error with a red highlight but it was too disruptive IMO as it prompted user input.