### PR TITLE
chore!: error handling

### DIFF
--- a/lua/Comment/api.lua
+++ b/lua/Comment/api.lua
@@ -13,6 +13,10 @@ local A = vim.api
 
 local api, core = {}, {}
 
+---API metamethods
+---@param that table
+---@param ctype CommentType
+---@return table
 function core.__index(that, ctype)
     local idxd = {}
     local mode, type = that.cmode, U.ctype[ctype]
@@ -22,17 +26,17 @@ function core.__index(that, ctype)
     ---In current-line linewise method, 'opmode' is not useful which is always equals to `char`
     ---but we need 'nil' here which is used for current-line
     function idxd.current(_, cfg)
-        Op.opfunc(nil, cfg or Config:get(), mode, type)
+        U.catch(Op.opfunc, nil, cfg or Config:get(), mode, type)
     end
 
     ---To comment lines with a count
     function idxd.count(count, cfg)
-        Op.count(count or A.nvim_get_vvar('count'), cfg or Config:get(), mode, type)
+        U.catch(Op.count, count or A.nvim_get_vvar('count'), cfg or Config:get(), mode, type)
     end
 
     ---@private
     ---To comment lines with a count, also dot-repeatable
-    ---WARNING: This is not part of the API but anyone case use it, if they want
+    ---WARN: This is not part of the API but anyone case use it, if they want
     function idxd.count_repeat(_, count, cfg)
         idxd.count(count, cfg)
     end
@@ -40,7 +44,7 @@ function core.__index(that, ctype)
     return setmetatable({}, {
         __index = idxd,
         __call = function(_, motion, cfg)
-            Op.opfunc(motion, cfg or Config:get(), mode, type)
+            U.catch(Op.opfunc, motion, cfg or Config:get(), mode, type)
         end,
     })
 end
@@ -173,13 +177,13 @@ api.insert = setmetatable({}, {
     __index = function(_, ctype)
         return {
             above = function(cfg)
-                Ex.insert_above(U.ctype[ctype], cfg or Config:get())
+                U.catch(Ex.insert_above, U.ctype[ctype], cfg or Config:get())
             end,
             below = function(cfg)
-                Ex.insert_below(U.ctype[ctype], cfg or Config:get())
+                U.catch(Ex.insert_below, U.ctype[ctype], cfg or Config:get())
             end,
             eol = function(cfg)
-                Ex.insert_eol(U.ctype[ctype], cfg or Config:get())
+                U.catch(Ex.insert_eol, U.ctype[ctype], cfg or Config:get())
             end,
         }
     end,

--- a/lua/Comment/ft.lua
+++ b/lua/Comment/ft.lua
@@ -193,7 +193,12 @@ function ft.get(lang, ctype)
     if not ctype then
         return vim.deepcopy(tuple)
     end
-    return tuple[ctype]
+    local cmt_str = tuple[ctype]
+    assert(
+        cmt_str or (ctype ~= require('Comment.utils').ctype.blockwise),
+        { msg = lang .. " doesn't support block comments!" }
+    )
+    return cmt_str
 end
 
 ---Get a language tree for a given range by walking the parse tree recursively.

--- a/lua/Comment/opfunc.lua
+++ b/lua/Comment/opfunc.lua
@@ -171,14 +171,14 @@ function Op.linewise(param)
         local uncomment = U.uncommenter(param.lcs, param.rcs, padding)
         for i, line in ipairs(param.lines) do
             if not U.ignore(line, pattern) then
-                param.lines[i] = uncomment(line)
+                param.lines[i] = uncomment(line) --[[@as string]]
             end
         end
     else
         local comment = U.commenter(param.lcs, param.rcs, padding, min_indent, nil, tabbed)
         for i, line in ipairs(param.lines) do
             if not U.ignore(line, pattern) then
-                param.lines[i] = comment(line)
+                param.lines[i] = comment(line) --[[@as string]]
             end
         end
     end


### PR DESCRIPTION
This adds error handling to the plugin, implemented with the help of `assert` and `xpcall`. Adding explicit error handling for the following cases:

- Invalid commenstring / Commenting is not supported like `json`
- When filetype doesn't support block comments like `yaml`
- Graceful handling of certain cases like uncommenting when there is nothing to uncomment.

---

fixes #221 
supersedes #277 