### PR TITLE
add .editorconfig support

### DIFF
--- a/lua/Comment/ft.lua
+++ b/lua/Comment/ft.lua
@@ -52,6 +52,7 @@ local L = setmetatable({
     dhall = { M.dash, M.haskell_b },
     dosbatch = { 'REM%s' },
     dot = { M.cxx_l, M.cxx_b },
+    editorconfig = { M.hash },
     eelixir = { M.html, M.html },
     elixir = { M.hash },
     elm = { M.dash, M.haskell_b },


### PR DESCRIPTION
Note: `;` is an alternate option for comments and also picked up by nvim.
Let me know if you want to keep things more simple or not.