### PR TITLE
adding vifm ft

### DIFF
--- a/lua/Comment/ft.lua
+++ b/lua/Comment/ft.lua
@@ -29,6 +29,7 @@ local M = {
     lisp_l = ';;%s',
     lisp_b = '#|%s|#',
     twig = '{#%s#}',
+    vim = '"%s',
 }
 
 ---Lang table that contains commentstring (linewise/blockwise) for multiple filetypes
@@ -124,8 +125,8 @@ local L = setmetatable({
     twig = { M.twig, M.twig },
     typescript = { M.cxx_l, M.cxx_b },
     typescriptreact = { M.cxx_l, M.cxx_b },
-    vim = { '"%s' },
-    vifm = { '"%s' },
+    vim = { M.vim },
+    vifm = { M.vim },
     vue = { M.html, M.html },
     xml = { M.html, M.html },
     xdefaults = { '!%s' },

--- a/lua/Comment/ft.lua
+++ b/lua/Comment/ft.lua
@@ -125,6 +125,7 @@ local L = setmetatable({
     typescript = { M.cxx_l, M.cxx_b },
     typescriptreact = { M.cxx_l, M.cxx_b },
     vim = { '"%s' },
+    vifm = { '"%s' },
     vue = { M.html, M.html },
     xml = { M.html, M.html },
     xdefaults = { '!%s' },


### PR DESCRIPTION
This adds the default commenting style for [vifm config files](https://github.com/vifm/vifm).