### PR TITLE
feat: add quarto filetype and enable languages using other languages' parsers

### DIFF
--- a/lua/Comment/ft.lua
+++ b/lua/Comment/ft.lua
@@ -103,6 +103,7 @@ local L = setmetatable({
     python = { M.hash }, -- Python doesn't have block comments
     php = { M.cxx_l, M.cxx_b },
     prisma = { M.cxx_l },
+    quarto = { M.html, M.html },
     r = { M.hash }, -- R doesn't have block comments
     readline = { M.hash },
     rego = { M.hash },
@@ -237,7 +238,9 @@ end
 ---@see comment.utils.CommentCtx
 function ft.calculate(ctx)
     local buf = A.nvim_get_current_buf()
-    local ok, parser = pcall(vim.treesitter.get_parser, buf)
+    local filetype = vim.bo.filetype
+    local parsername = require 'nvim-treesitter.parsers'.filetype_to_parsername[filetype] or filetype
+    local ok, parser = pcall(vim.treesitter.get_parser, buf, parsername)
 
     if not ok then
         return ft.get(vim.bo.filetype, ctx.ctype) --[[ @as string ]]

--- a/lua/Comment/ft.lua
+++ b/lua/Comment/ft.lua
@@ -150,24 +150,7 @@ local L = setmetatable({
 ---that don't have their own parser (yet).
 ---From: <https://github.com/nvim-treesitter/nvim-treesitter/blob/cda8b291ef6fc4e04036e2ea6cf0de8aa84c2656/lua/nvim-treesitter/parsers.lua#L4-L23>.
 local filetype_to_parsername = {
-  javascriptreact = "javascript",
-  ecma = "javascript",
-  jsx = "javascript",
-  PKGBUILD = "bash",
-  html_tags = "html",
-  ["typescript.tsx"] = "tsx",
-  ["html.handlebars"] = "glimmer",
-  systemverilog = "verilog",
-  cls = "latex",
-  sty = "latex",
-  OpenFOAM = "foam",
-  pandoc = "markdown",
-  rmd = "markdown",
   quarto = "markdown",
-  cs = "c_sharp",
-  tape = "vhs",
-  dosini = "ini",
-  confini = "ini",
 }
 
 local ft = {}

--- a/lua/Comment/ft.lua
+++ b/lua/Comment/ft.lua
@@ -146,6 +146,30 @@ local L = setmetatable({
     end,
 })
 
+---Maps a filteype to a parsername for filetypes
+---that don't have their own parser (yet).
+---From: <https://github.com/nvim-treesitter/nvim-treesitter/blob/cda8b291ef6fc4e04036e2ea6cf0de8aa84c2656/lua/nvim-treesitter/parsers.lua#L4-L23>.
+local filetype_to_parsername = {
+  javascriptreact = "javascript",
+  ecma = "javascript",
+  jsx = "javascript",
+  PKGBUILD = "bash",
+  html_tags = "html",
+  ["typescript.tsx"] = "tsx",
+  ["html.handlebars"] = "glimmer",
+  systemverilog = "verilog",
+  cls = "latex",
+  sty = "latex",
+  OpenFOAM = "foam",
+  pandoc = "markdown",
+  rmd = "markdown",
+  quarto = "markdown",
+  cs = "c_sharp",
+  tape = "vhs",
+  dosini = "ini",
+  confini = "ini",
+}
+
 local ft = {}
 
 ---Sets a commentstring(s) for a filetype/language
@@ -239,7 +263,7 @@ end
 function ft.calculate(ctx)
     local buf = A.nvim_get_current_buf()
     local filetype = vim.bo.filetype
-    local parsername = require 'nvim-treesitter.parsers'.filetype_to_parsername[filetype] or filetype
+    local parsername = filetype_to_parsername[filetype] or filetype
     local ok, parser = pcall(vim.treesitter.get_parser, buf, parsername)
 
     if not ok then


### PR DESCRIPTION
This requires the `nvim-treesiter` plugin, as the quarto filetype does not yet have its own treesitter grammar, and this now merged PR in nvim-treesitter: https://github.com/nvim-treesitter/nvim-treesitter/pull/4212/files

It also makes Comment.nvim work for the other languages in the same list:

https://github.com/nvim-treesitter/nvim-treesitter/blob/cda8b291ef6fc4e04036e2ea6cf0de8aa84c2656/lua/nvim-treesitter/parsers.lua#L4-L23