### PR TITLE
feat: add autohotkey support

### DIFF
--- a/lua/Comment/ft.lua
+++ b/lua/Comment/ft.lua
@@ -38,6 +38,7 @@ local M = {
 local L = setmetatable({
     arduino = { M.cxx_l, M.cxx_b },
     applescript = { M.hash },
+    autohotkey = { ";%s", M.cxx_b },
     bash = { M.hash },
     bib = { M.latex },
     c = { M.cxx_l, M.cxx_b },


### PR DESCRIPTION
https://www.autohotkey.com/docs/v1/Language.htm#comments
https://www.autohotkey.com/docs/v2/Language.htm#comments

This includes block comments, but autohotkey restricts the end tag to appearing at the start of a line, or in v2 at the end of a line. With those restrictions, it may be better to only define the line comment.