### PR TITLE
feat(ft): add `dts` support

### DIFF
--- a/lua/Comment/ft.lua
+++ b/lua/Comment/ft.lua
@@ -55,6 +55,7 @@ local L = setmetatable({
     dhall = { M.dash, M.haskell_b },
     dosbatch = { 'REM%s' },
     dot = { M.cxx_l, M.cxx_b },
+    dts = { M.cxx_l, M.cxx_b },
     editorconfig = { M.hash },
     eelixir = { M.html, M.html },
     elixir = { M.hash },


### PR DESCRIPTION
Doc: https://www.kernel.org/doc/Documentation/devicetree/booting-without-of.txt

`The format of the .dts "source" file is "C" like, supports C and C++ style comments.`