### PR TITLE
feat(ft): add `nextflow` support

### DIFF
--- a/lua/Comment/ft.lua
+++ b/lua/Comment/ft.lua
@@ -96,6 +96,7 @@ local L = setmetatable({
     make = { M.hash },
     mbsyncrc = { M.dbl_hash },
     meson = { M.hash },
+    nextflow = { M.cxx_l, M.cxx_b },
     nim = { M.hash, '#[%s]#' },
     nix = { M.hash, M.cxx_b },
     nu = { M.hash },


### PR DESCRIPTION
This PR adds support for the [Nextflow](https://www.nextflow.io/) (`nextflow`) filetype,. Nextflow is a Groovy-based workflow management system used heavily in _e.g._ bioinformatics.