### PR TITLE
feat(ft): add `idris2` support

### DIFF
--- a/lua/Comment/ft.lua
+++ b/lua/Comment/ft.lua
@@ -80,6 +80,7 @@ local L = setmetatable({
     html = { M.html, M.html },
     htmldjango = { M.html, M.html },
     idris = { M.dash, M.haskell_b },
+    idris2 = { M.dash, M.haskell_b },
     ini = { M.hash },
     java = { M.cxx_l, M.cxx_b },
     javascript = { M.cxx_l, M.cxx_b },


### PR DESCRIPTION
Idris 2 uses its own ft for some reason (probably due to it being very non-backwards compatible since it uses QTT and an entirely different compiler).