### PR TITLE
feat(ft): add `robot` (Robotframework) support

### DIFF
--- a/lua/Comment/ft.lua
+++ b/lua/Comment/ft.lua
@@ -114,6 +114,7 @@ local L = setmetatable({
     readline = { M.hash },
     rego = { M.hash },
     remind = { M.hash },
+    robot = { M.hash }, -- Robotframework doesn't have block comments
     ruby = { M.hash },
     rust = { M.cxx_l, M.cxx_b },
     scala = { M.cxx_l, M.cxx_b },


### PR DESCRIPTION
Submitting this PR to add support for [Robotframework](https://robotframework.org/) (*.robot) files. Robotframework **doesn't** have block comments.