### PR TITLE
feat(ft): add `ron` support

### DIFF
--- a/lua/Comment/ft.lua
+++ b/lua/Comment/ft.lua
@@ -119,6 +119,7 @@ local L = setmetatable({
     rego = { M.hash },
     remind = { M.hash },
     robot = { M.hash }, -- Robotframework doesn't have block comments
+    ron = { M.cxx_l, M.cxx_b },
     ruby = { M.hash },
     rust = { M.cxx_l, M.cxx_b },
     scala = { M.cxx_l, M.cxx_b },


### PR DESCRIPTION
Came across the RON format while configuring `gitui` and wanted to use some comments :)

See specification here:
* basic: https://github.com/ron-rs/ron/wiki/Specification#comments
* actual grammar: https://github.com/ron-rs/ron/blob/master/docs/grammar.md#whitespace-and-comments

(small thing, the basic doc don't include the block comment (`/* */`) for some reason, the actual spec does though.