### PR TITLE
add astro comment

### DIFF
--- a/lua/Comment/ft.lua
+++ b/lua/Comment/ft.lua
@@ -14,6 +14,7 @@ local A = vim.api
 
 ---Common commentstring shared b/w multiple languages
 local M = {
+    astro = '<!--%s-->', --same as html
     cxx_l = '//%s',
     cxx_b = '/*%s*/',
     dbl_hash = '##%s',


### PR DESCRIPTION
identical to html. 
astro files use javascript / typescript in the frontmatter section of a .astro file, which is already supported.  Tested that comments work in both fields of Astro file, ie:

---
// js
---

<!-- astro -->

~
~