### PR TITLE
feat(ft): add `sbt` support

### DIFF
--- a/lua/Comment/ft.lua
+++ b/lua/Comment/ft.lua
@@ -121,6 +121,7 @@ local L = setmetatable({
     robot = { M.hash }, -- Robotframework doesn't have block comments
     ruby = { M.hash },
     rust = { M.cxx_l, M.cxx_b },
+    sbt = { M.cxx_l, M.cxx_b },
     scala = { M.cxx_l, M.cxx_b },
     scheme = { M.lisp_l, M.lisp_b },
     sh = { M.hash },


### PR DESCRIPTION
SBT files are essentially Scala files and exist in most Scala projects. It supports the same comments as scala.