### PR TITLE
docs(plugin): add `lazy.nvim` install instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 - With [lazy.nvim](https://github.com/folke/lazy.nvim)
 
 ```lua
--- add this to your lua/plugins.rb, lua/plugins/init.rb,  or the file you keep your other plugins:
+-- add this to your lua/plugins.lua, lua/plugins/init.lua,  or the file you keep your other plugins:
 {
     'numToStr/Comment.nvim',
     opts = {

--- a/README.md
+++ b/README.md
@@ -17,6 +17,18 @@
 
 ### 🚀 Installation
 
+- With [lazy.nvim](https://github.com/folke/lazy.nvim)
+
+```lua
+{
+    'numToStr/Comment.nvim',
+    opts = {
+        -- add any options here
+    },
+    event = "BufRead",
+}
+```
+
 - With [packer.nvim](https://github.com/wbthomason/packer.nvim)
 
 ```lua

--- a/README.md
+++ b/README.md
@@ -20,13 +20,15 @@
 - With [lazy.nvim](https://github.com/folke/lazy.nvim)
 
 ```lua
+-- add this to your lua/plugins.rb, lua/plugins/init.rb,  or the file you keep your other plugins:
 {
     'numToStr/Comment.nvim',
     opts = {
         -- add any options here
     },
-    event = "BufRead",
+    lazy = false,
 }
+
 ```
 
 - With [packer.nvim](https://github.com/wbthomason/packer.nvim)


### PR DESCRIPTION
An alternative to https://github.com/numToStr/Comment.nvim/pull/367 , without listing out all the keys.