### PR TITLE
[Doc] Fixed lazy installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@
     opts = {
         -- add any options here
     },
-    lazy = false,
+    -- Also change this if you change your keybindings
+    keys = { 'gcc', 'gbc', 'gco', 'gcO', 'gcA', { 'gc', mode = {'v', 'n'} }, { 'gb', mode = {'v', 'n'} } },
 }
 
 ```


### PR DESCRIPTION
Not sure, why the current instructions recommend disabling lazy loading, but I think we can do better :)

I'd assume the main way to interact with `Comment.nvim` is through the keybindings, so loading the plugin when a related key press is detected should be fine.