### PR TITLE
feat(ft): add asm support

### DIFF
--- a/lua/Comment/ft.lua
+++ b/lua/Comment/ft.lua
@@ -40,6 +40,7 @@ local M = {
 local L = setmetatable({
     arduino = { M.cxx_l, M.cxx_b },
     applescript = { M.hash },
+    asm = { M.hash },
     astro = { M.html },
     autohotkey = { M.semicolon, M.cxx_b },
     bash = { M.hash },


### PR DESCRIPTION
[GNU assembler](https://en.wikipedia.org/wiki/GNU_Assembler) use `#` to comment string for x86-64 and RISC-V