### PR TITLE
Remove lazy=false

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,7 @@
     'numToStr/Comment.nvim',
     opts = {
         -- add any options here
-    },
-    lazy = false,
+    }
 }
 
 ```


### PR DESCRIPTION
`lazy=false` is a default value for lazy.nvim. Explicitly setting it is redundant and leaves users confused. As a new user, I assumed lazy-loading Comment.nvim would break the plugin, but that's not the case.