### PR TITLE
feat(ft): add gdshader support

### DIFF
--- a/lua/Comment/ft.lua
+++ b/lua/Comment/ft.lua
@@ -72,6 +72,7 @@ local L = setmetatable({
     fsharp = { M.cxx_l, M.fsharp_b },
     gdb = { M.hash },
     gdscript = { M.hash },
+    gdshader = { M.cxx_l, M.cxx_b },
     gitignore = { M.hash },
     gleam = { M.cxx_l },
     glsl = { M.cxx_l, M.cxx_b },


### PR DESCRIPTION
Add support for filetype `gdshader`, which is the shader programming language of [Godot game engine](https://github.com/godotengine/godot).

Comment rules are explained [here](https://docs.godotengine.org/en/stable/tutorials/shaders/shaders_style_guide.html#comment-spacing).