### PR TITLE
feat(ft): add hyprlang support

### DIFF
--- a/lua/Comment/ft.lua
+++ b/lua/Comment/ft.lua
@@ -86,6 +86,7 @@ local L = setmetatable({
     heex = { M.html, M.html },
     html = { M.html, M.html },
     htmldjango = { M.html, M.html },
+    hyprlang = { M.hash }, -- Hyprlang doesn't have block comments
     idris = { M.dash, M.haskell_b },
     idris2 = { M.dash, M.haskell_b },
     ini = { M.hash },


### PR DESCRIPTION
This adds support for hyprland config comments support.

https://wiki.hyprland.org/Configuring/Configuring-Hyprland/#comments
The hyprlang grammar is given by https://github.com/tree-sitter-grammars/tree-sitter-hyprlang