### PR TITLE
fix(docs): define pre_hook as a function

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,9 @@ You can also integrate [nvim-ts-context-commentstring](https://github.com/Joosep
 
 ```lua
 {
-    pre_hook = require('ts_context_commentstring.integrations.comment_nvim').create_pre_hook(),
+    pre_hook = function()
+        require('ts_context_commentstring.integrations.comment_nvim').create_pre_hook()
+    end,
 }
 ```
 


### PR DESCRIPTION
".. so that it becomes a closure and doesn't get evaluated when the file is parsed."

https://github.com/JoosepAlviste/nvim-ts-context-commentstring/issues/58#issuecomment-1691415478