### PR TITLE
fix(opfunc): fix linewise comment for partial visual selection in single line (Bug#476)

### DIFF
--- a/lua/Comment/opfunc.lua
+++ b/lua/Comment/opfunc.lua
@@ -46,7 +46,7 @@ function Op.opfunc(motion, cfg, cmode, ctype)
     local ctx = {
         cmode = cmode,
         cmotion = cmotion,
-        ctype = is_blockx and U.ctype.blockwise or ctype,
+        ctype = ctype,
         range = range,
     }
 
@@ -62,7 +62,7 @@ function Op.opfunc(motion, cfg, cmode, ctype)
         range = range,
     }
 
-    if motion ~= nil and (is_blockx or ctype == U.ctype.blockwise) then
+    if motion ~= nil and ctype == U.ctype.blockwise then
         ctx.cmode = Op.blockwise(params, is_partial)
     else
         ctx.cmode = Op.linewise(params)
@@ -139,7 +139,7 @@ function Op.linewise(param)
     local cmode = U.cmode.uncomment
 
     ---When commenting multiple line, it is to be expected that indentation should be preserved
-    ---So, When looping over multiple lines we need to store the indentation of the mininum length (except empty line)
+    ---So, When looping over multiple lines we need to store the indentation of the minimum length (except empty line)
     ---Which will be used to semantically comment rest of the lines
     local min_indent, tabbed = -1, false
 


### PR DESCRIPTION
This PR addresses issue #476 where creating a linewise comment inadvertently produces a blockwise comment under certain conditions, specifically in VISUAL mode when a portion of a single line is selected.

When selecting a part of a single line in VISUAL mode, such as the printf in the following code:
```C
int main() {
    printf("Hello World");
}
```

Pressing either `gc` or `gb` currently results in:
```C
int main() {
    /* printf */("Hello World");
}
```

For a linewise comment using `gc`, the expected result should be:
```C
int main() {
    // printf("Hello World");
}
```

This PR fixes this problem both for the shortcut (`gc`) and the api command (`require'Comment.api'.toggle.linewise.current()`). Explicitly using a blockwise comment (e.g. using `gb`) still works.