### PR TITLE
Add option always_use_block

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,9 @@ Following are the **default** config for the [`setup()`](#setup). If you want to
     padding = true,
     ---Whether the cursor should stay at its position
     sticky = true,
+    ---If filetype of the buffer is part of the following list
+    ---then only block comments will be used, even for toggler.line keymap
+    only_block_ft = {},
     ---Lines to be ignored while (un)comment
     ignore = nil,
     ---LHS of toggle mappings in NORMAL mode

--- a/doc/Comment.txt
+++ b/doc/Comment.txt
@@ -127,27 +127,29 @@ CommentConfig                                     *comment.config.CommentConfig*
     Plugin's configuration
 
     Fields: ~
-        {padding}    (boolean|fun():boolean)     Controls space between the comment
-                                                 and the line (default: 'true')
-        {sticky}     (boolean)                   Whether cursor should stay at the
-                                                 same position. Only works in NORMAL
-                                                 mode mappings (default: 'true')
-        {ignore}     (string|fun():string)       Lua pattern used to ignore lines
-                                                 during (un)comment (default: 'nil')
-        {mappings}   (Mappings|false)            Enables |comment.keybindings|
-                                                 NOTE: If given 'false', then the
-                                                 plugin won't create any mappings
-        {toggler}    (Toggler)                   See |comment.config.Toggler|
-        {opleader}   (Opleader)                  See |comment.config.Opleader|
-        {extra}      (ExtraMapping)              See |comment.config.ExtraMapping|
-        {pre_hook}   (fun(c:CommentCtx):string)  Function to call before (un)comment.
-                                                 It is called with a {ctx} argument
-                                                 of type |comment.utils.CommentCtx|
-                                                 (default: 'nil')
-        {post_hook}  (fun(c:CommentCtx))         Function to call after (un)comment.
-                                                 It is called with a {ctx} argument
-                                                 of type |comment.utils.CommentCtx|
-                                                 (default: 'nil')
+        {padding}       (boolean|fun():boolean)    Controls space between the comment
+                                                   and the line (default: 'true')
+        {sticky}        (boolean)                  Whether cursor should stay at the
+                                                   same position. Only works in NORMAL
+                                                   mode mappings (default: 'true')
+        {only_block_ft} (string[])                 Always use block comments
+                                                   (default: '{}')
+        {ignore}        (string|fun():string)      Lua pattern used to ignore lines
+                                                   during (un)comment (default: 'nil')
+        {mappings}      (Mappings|false)           Enables |comment.keybindings|
+                                                   NOTE: If given 'false', then the
+                                                   plugin won't create any mappings
+        {toggler}       (Toggler)                  See |comment.config.Toggler|
+        {opleader}      (Opleader)                 See |comment.config.Opleader|
+        {extra}         (ExtraMapping)             See |comment.config.ExtraMapping|
+        {pre_hook}      (fun(c:CommentCtx):string) Function to call before (un)comment.
+                                                   It is called with a {ctx} argument
+                                                   of type |comment.utils.CommentCtx|
+                                                   (default: 'nil')
+        {post_hook}     (fun(c:CommentCtx))        Function to call after (un)comment.
+                                                   It is called with a {ctx} argument
+                                                   of type |comment.utils.CommentCtx|
+                                                   (default: 'nil')
 
 
 Mappings                                               *comment.config.Mappings*

--- a/lua/Comment/config.lua
+++ b/lua/Comment/config.lua
@@ -28,6 +28,10 @@
 ---same position. Only works in NORMAL
 ---mode mappings (default: 'true')
 ---@field sticky boolean
+---Use only block comments if the
+---filetype is in the following
+---array of filetypes (default: {})
+---@field only_block_ft string[]
 ---Lua pattern used to ignore lines
 ---during (un)comment (default: 'nil')
 ---@field ignore string|fun():string
@@ -83,6 +87,7 @@ local Config = {
     config = {
         padding = true,
         sticky = true,
+        block_comments_ft = {},
         mappings = {
             basic = true,
             extra = true,

--- a/lua/Comment/extra.lua
+++ b/lua/Comment/extra.lua
@@ -22,12 +22,13 @@ end
 ---@param cfg CommentConfig
 local function ins_on_line(lnum, ctype, cfg)
     local row, col = unpack(A.nvim_win_get_cursor(0))
+    local block_ft = vim.tbl_contains(cfg.only_block_ft, vim.bo.ft)
 
     ---@type CommentCtx
     local ctx = {
         cmode = U.cmode.comment,
         cmotion = U.cmotion.line,
-        ctype = ctype,
+        ctype = block_ft and U.ctype.blockwise or ctype,
         range = { srow = row, scol = col, erow = row, ecol = col },
     }
 
@@ -65,12 +66,13 @@ end
 ---@param cfg CommentConfig
 function extra.insert_eol(ctype, cfg)
     local srow, scol = unpack(A.nvim_win_get_cursor(0))
+    local block_ft = vim.tbl_contains(cfg.only_block_ft, vim.bo.ft)
 
     ---@type CommentCtx
     local ctx = {
         cmode = U.cmode.comment,
         cmotion = U.cmotion.line,
-        ctype = ctype,
+        ctype = block_ft and U.ctype.blockwise or ctype,
         range = { srow = srow, scol = scol, erow = srow, ecol = scol },
     }
     local lcs, rcs = U.parse_cstr(cfg, ctx)

--- a/lua/Comment/opfunc.lua
+++ b/lua/Comment/opfunc.lua
@@ -32,7 +32,8 @@ function Op.opfunc(motion, cfg, cmode, ctype)
     -- If we are doing char or visual motion on the same line
     -- then we would probably want block comment instead of line comment
     local is_partial = cmotion == U.cmotion.char or cmotion == U.cmotion.v
-    local is_blockx = is_partial and range.srow == range.erow
+    local block_ft = vim.tbl_contains(cfg.only_block_ft, vim.bo.ft)
+    local is_blockx = block_ft or (is_partial and range.srow == range.erow)
 
     local lines = U.get_lines(range)
 


### PR DESCRIPTION
Problem:
Sometimes coding rules/preferences makes one need to only use block comments for certain filetypes.
With the current implementation of this plugin you have to memorize different mappings for regular and block comments (I very often use regular comment mapping instead of block as I constantly switch between c and python files). Also you don't have mappings for block comments in "extra" actions (eol, above, below).

Solution:
Use only block comments if the filetype is in always_use_block