### PR TITLE
fix(ft): handles mismatch between parser name and filetype

### DIFF
--- a/lua/Comment/ft.lua
+++ b/lua/Comment/ft.lua
@@ -248,6 +248,9 @@ end
 ---ft.get('ansible.yaml') -- { '#%s' }
 ---@usage ]]
 function ft.get(lang, ctype)
+    -- NOTE:  Add conversion for those parser names doesn't match to filetype
+    lang = lang == 'c_sharp' and 'cs' or lang
+    lang = lang == 'powershell' and 'ps1' or lang
     local tuple = L[lang]
     if not tuple then
         return nil


### PR DESCRIPTION
Basically same as #490 but I think it's a better place to do that handling