### PR TITLE
fix: fix treesitter `get_parser` for nvim `v0.12`

### DIFF
--- a/lua/Comment/ft.lua
+++ b/lua/Comment/ft.lua
@@ -293,7 +293,7 @@ end
 function ft.calculate(ctx)
     local ok, parser = pcall(vim.treesitter.get_parser, A.nvim_get_current_buf())
 
-    if not ok then
+    if not parser then
         return ft.get(vim.bo.filetype, ctx.ctype) --[[ @as string ]]
     end
 


### PR DESCRIPTION
Under `nvim` `0.12` `vim.treesitter.get_parser()` call does not throws error. It just return `null`.
This PR fixes this problem.